### PR TITLE
Removes old code example

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -261,7 +261,7 @@ const sleep = ms => new Promise(r => setTimeout(r, ms));
 
 async function authenticate(req, res, next) {
   let token = req.getHeader('authorization');
-  if (!token) return app.send(res, 401);
+  if (!token) return ((res.statusCode=401) && res.end('No token!'));
   req.user = await Users.find(token); // <== fake
   next(); // done, woot!
 }


### PR DESCRIPTION
Example showed the use of `app.send()` which was removed in v0.3.0. I've taken its equivalent from later on in the README as opposed to replacing it with the `@polka/send` packages (because at present they're not mentioned in this file).