### PR TITLE
Allow alternative server by options

### DIFF
--- a/examples/with-uws/index.js
+++ b/examples/with-uws/index.js
@@ -3,10 +3,8 @@ const polka = require('polka');
 
 const { PORT=3000 } = process.env;
 
-const { handler } = polka().get('/', (req, res) => {
+polka({ server: http }).get('/', (req, res) => {
 	res.end('Hello');
-});
-
-http.createServer(handler).listen(PORT, err => {
+}).listen(PORT, err => {
 	console.log(`> Running on localhost:${PORT}`);
 });

--- a/packages/polka/index.js
+++ b/packages/polka/index.js
@@ -34,7 +34,7 @@ class Polka extends Router {
 		this.bwares = {};
 		this.parse = parseurl;
 		this.handler = this.handler.bind(this);
-		this.server = http.createServer(this.handler);
+		this.server = opts.server && opts.server.createServer ? opts.server.createServer(this.handler) : http.createServer(this.handler);
 		this.onError = opts.onError || onError; // catch-all handler
 		this.onNoMatch = opts.onNoMatch || this.onError.bind(null, { code:404 });
 	}


### PR DESCRIPTION
Custom http server can be passed to options.
It has check for server in options to have .createServer method or else use default

Update examples where possible for usage of server option.
Excluded https as it takes options for ssl.

*Cleanup of #13*

Example
```js
import http from 'somemagic-http-server';

polka({ server: http });
```