### PR TITLE
Allow sub-apps to be mounted on the root path

### DIFF
--- a/packages/polka/index.js
+++ b/packages/polka/index.js
@@ -40,7 +40,18 @@ class Polka extends Router {
 	}
 
 	use(base, ...fns) {
-		if (typeof base === 'function') {
+		if (base instanceof Polka) {
+			// Flatten routes into primary polka instance
+			for (const method in base.routes) {
+				if (base.routes[method].length) {
+					base.routes[method].forEach((route) => {
+						const pattern = route[0].old;
+						if (this.handlers[method][pattern]) return; // avoid overwriting existing routes
+						this[method.toLowerCase()](pattern, base.handlers[method][pattern]);
+					})
+				}
+			}
+		} else if (typeof base === 'function') {
 			this.wares = this.wares.concat(base, fns);
 		} else {
 			base = lead(base);

--- a/readme.md
+++ b/readme.md
@@ -89,7 +89,7 @@ A handler when no route definitions were matched. Change this if you don't like 
 Its signature is `(req, res)` and requires that you terminate the response.
 
 
-### use(base, ...fn)
+### use([base,] ...fn)
 
 Attach [middleware(s)](#middleware) and/or sub-application(s) to the server. These will execute _before_ your routes' [handlers](#handlers).
 
@@ -106,7 +106,7 @@ Type: `Function|Array`
 
 You may pass one or more functions at a time. Each function must have the standardized `(req, res, next)` signature.
 
-You may also pass a sub-application, which _must_ be accompanied by a `base` pathname.
+You may also pass a sub-application without a `base` pathname, which will have its routes hoisted to the primary polka instance.
 
 Please see [`Middleware`](#middleware) and [Express' middleware examples](http://expressjs.com/en/4x/api.html#middleware-callback-function-examples) for more info.
 


### PR DESCRIPTION
Express.js allows you to mount sub-applications to the root path (aka. it doesn't require a separate entry path). This change hoists routes from a provided Polka instance to the primary instance.