### PR TITLE
Fix TypeError in strict mode

### DIFF
--- a/packages/polka/index.js
+++ b/packages/polka/index.js
@@ -14,7 +14,6 @@ function value(x) {
 
 function mutate(str, req) {
 	req.url = req.url.substring(str.length) || '/';
-	req.path = req.path.substring(str.length) || '/';
 }
 
 function onError(err, req, res, next) {
@@ -71,7 +70,7 @@ class Polka extends Router {
 		info = info || this.parse(req);
 		let fns=[], arr=this.wares, obj=this.find(req.method, info.pathname);
 		req.originalUrl = req.originalUrl || req.url;
-		let base = value(req.path = info.pathname);
+		let base = value(info.pathname);
 		if (this.bwares[base] !== void 0) {
 			arr = arr.concat(this.bwares[base]);
 		}


### PR DESCRIPTION
Using polka as a handler for firebase cloud functions will cause the following error to be thrown: "TypeError: Cannot set property path of #<IncomingMessage> which has only a getter".

Basically, "strict mode" won't allow changing the request path since it got no setter implemented.
These changes fix it.
