### PR TITLE
fix: remove height attribute to prevent scaling issues on mobile

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -1,5 +1,5 @@
 <div align="center">
-  <img src="https://github.com/lukeed/polka/raw/master/polka.png" alt="Polka" width="400" height="300" />
+  <img src="https://github.com/lukeed/polka/raw/master/polka.png" alt="Polka" width="400" />
 </div>
 
 <h1 align="center">Polka</h1>


### PR DESCRIPTION
with the `height`:
![Bildschirmfoto 2019-05-02 um 09 33 36](https://user-images.githubusercontent.com/827205/57061528-7d668400-6cbd-11e9-9e0a-79fb25728ba1.png)

without the `height`:
![Bildschirmfoto 2019-05-02 um 09 34 04](https://user-images.githubusercontent.com/827205/57061527-7ccded80-6cbd-11e9-9fa6-fd6e4df244dd.png)
