### PR TITLE
fix(send): avoid duplicating content-type and content-length headers

### DIFF
--- a/packages/send/index.mjs
+++ b/packages/send/index.mjs
@@ -1,8 +1,8 @@
 import { STATUS_CODES } from 'http';
 import { createHash } from 'crypto';
 
-const TYPE = 'Content-Type';
-const LENGTH = 'Content-Length';
+const TYPE = 'content-type';
+const LENGTH = 'content-length';
 const OSTREAM = 'application/octet-stream';
 
 export default function (res, code=200, data='', headers={}) {

--- a/packages/send/index.mjs
+++ b/packages/send/index.mjs
@@ -1,8 +1,8 @@
 import { STATUS_CODES } from 'http';
 import { createHash } from 'crypto';
 
-const TYPE = 'content-type';
-const LENGTH = 'content-length';
+const TYPE = 'Content-Type';
+const LENGTH = 'Content-Length';
 const OSTREAM = 'application/octet-stream';
 
 export default function (res, code=200, data='', headers={}) {
@@ -29,6 +29,8 @@ export default function (res, code=200, data='', headers={}) {
 
 	obj[TYPE] = type || 'text/plain';
 	obj[LENGTH] = Buffer.byteLength(data);
+	delete obj[LENGTH.toLowerCase()];
+	delete obj[TYPE.toLowerCase()];
 
 	if (obj.etag) {
 		let hash = createHash('sha1').update(data).digest('base64').substring(0, 27);

--- a/packages/send/test/index.js
+++ b/packages/send/test/index.js
@@ -4,8 +4,8 @@ import { join } from 'path';
 import { Response, toStatusText } from './util';
 import send from '../index.mjs';
 
-const TYPE = 'content-type';
-const LENGTH = 'content-length';
+const TYPE = 'Content-Type';
+const LENGTH = 'Content-Length';
 const INPUT = require.resolve('../');
 
 test('(send) exports', t => {

--- a/packages/send/test/index.js
+++ b/packages/send/test/index.js
@@ -4,8 +4,8 @@ import { join } from 'path';
 import { Response, toStatusText } from './util';
 import send from '../index.mjs';
 
-const TYPE = 'Content-Type';
-const LENGTH = 'Content-Length';
+const TYPE = 'content-type';
+const LENGTH = 'content-length';
 const INPUT = require.resolve('../');
 
 test('(send) exports', t => {

--- a/packages/send/test/index.js
+++ b/packages/send/test/index.js
@@ -166,6 +166,29 @@ test('(send) headers – Object', t => {
 	t.end();
 });
 
+test('(send) headers – Object :: case insensitive', t => {
+	let obj = { foo:123 };
+	let str = JSON.stringify(obj);
+
+	let foo = new Response();
+	send(foo, 500, obj, { 'content-type':'foo/bar' });
+	t.is(foo.statusCode, 500, 'set statusCode: 500');
+	t.is(foo.getHeaderNames().length, 2, 'total headers added: 2');
+	t.is(foo.getHeader(TYPE), 'foo/bar', 'allow Content-Type override: foo/bar');
+	t.is(foo.getHeader(LENGTH), str.length, `custom header[length]: ${str.length}`);
+	t.is(foo.body, str, `custom body: ${str}`);
+
+	let bar = new Response();
+	send(bar, 500, obj, { 'cOnTeNt-TyPe':'foo/bar' });
+	t.is(bar.statusCode, 500, 'set statusCode: 500');
+	t.is(bar.getHeaderNames().length, 2, 'total headers added: 2');
+	t.is(bar.getHeader(TYPE), 'foo/bar', 'allow Content-Type override: foo/bar');
+	t.is(bar.getHeader(LENGTH), str.length, `custom header[length]: ${str.length}`);
+	t.is(bar.body, str, `custom body: ${str}`);
+
+	t.end();
+});
+
 test('(send) headers – Object :: respect existing', t => {
 	let obj = { foo:123 };
 	let str = JSON.stringify(obj);


### PR DESCRIPTION
When custom `Content-Type` header (regardless of case) is given:

    send(500, 'HELO', { 'Content-Type': 'application/problem+json' })

It is duplicated in the response:

    $ curl http://localhost:8080/test

    > GET /test HTTP/1.1
    > Host: localhost:8080
    > User-Agent: curl/7.60.0
    > Accept: application/foo+json
    >
    < HTTP/1.1 500 Internal Server Error
    < content-type: application/problem+json  <-- HERE
    < Content-Type: application/problem+json  <-- HERE
    < Content-Length: 68
    < Date: Sun, 07 Jul 2019 14:00:50 GMT
    < Connection: keep-alive

That's because it's converted to lower case at line 11 and then assigned
to key 'Content-Type' at line 30.

It's weird that it's not duplicated in `res.getHeaderNames()`, nor
`res.getHeaders()`, so the tests pass.