### PR TITLE
Feat: Allow RegExp route patterns

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: node_js
 
 node_js:
-  - 8
+  - 10
 
 before_script:
   - npm i -g nyc@13 codecov

--- a/packages/polka/index.mjs
+++ b/packages/polka/index.mjs
@@ -24,11 +24,17 @@ class Polka extends Router {
 		} else if (base === '/') {
 			super.use(base, fns);
 		} else {
-			base.startsWith('/') || (base=`/${base}`);
 			super.use(base,
 				(req, _, next) => {
-					req.url = req.url.substring(base.length) || '/';
-					req.path = req.path.substring(base.length) || '/';
+					if (typeof base === 'string') {
+						let len = base.length;
+						base.startsWith('/') || len++;
+						req.url = req.url.substring(len) || '/';
+						req.path = req.path.substring(len) || '/';
+					} else {
+						req.url = req.url.replace(base, '') || '/';
+						req.path = req.path.replace(base, '') || '/';
+					}
 					next();
 				},
 				fns.map(fn => fn instanceof Polka ? fn.attach : fn),

--- a/packages/polka/package.json
+++ b/packages/polka/package.json
@@ -17,6 +17,6 @@
   },
   "dependencies": {
     "@polka/url": "^1.0.0-next.3",
-    "trouter": "^3.0.2"
+    "trouter": "^3.1.0"
   }
 }

--- a/packages/polka/test/index.js
+++ b/packages/polka/test/index.js
@@ -618,7 +618,7 @@ if (hasNamedGroups) {
 
 		let app = (
 			polka()
-				.use('/movies', (req, res, next) => {
+				.use(/movies/i, (req, res, next) => {
 					req.foo = 'foo';
 					next();
 				}) // global

--- a/packages/polka/test/index.js
+++ b/packages/polka/test/index.js
@@ -614,7 +614,7 @@ test('(polka) middleware w/ wildcard', async t => {
 
 if (hasNamedGroups) {
 	test('(polka) RegExp routes', async t => {
-		t.plan(22);
+		t.plan(29);
 
 		let app = (
 			polka()
@@ -627,11 +627,19 @@ if (hasNamedGroups) {
 				}) // global
 				.use(/^\/books[/](?<title>[^/]+)/i, (req, res) => {
 					t.pass('runs the /books/<title>/i middleware group');
-					t.is(req.originalUrl, '/books/narnia?foo', '~> sees correct `originalUrl` value');
-					t.is(req.path, '/', '~> sees correct `path` value – REPLACED/MATCHED ALL BCUZ PATTERN');
+					t.is(req.originalUrl, '/books/narnia/comments?foo', '~> sees correct `originalUrl` value');
+					t.is(req.path, '/comments', '~> sees correct `path` value – REPLACED PATTERN');
+					t.is(req.url, '/comments?foo', '~> sees correct `url` value – REPLACED PATTERN');
 					t.is(req.params.title, 'narnia', '~> receives correct `params.title` value');
 					t.same(req.query, { foo: '' }, '~> receives correct `req.query` value');
 					res.end('cya~!');
+				}) // global
+				.use(/^\/songs.*/i, (req, res) => {
+					t.pass('runs the /songs.*/i middleware group');
+					t.is(req.originalUrl, '/songs/foo/bar/baz', '~> sees correct `originalUrl` value');
+					t.is(req.path, '/', '~> sees correct `path` value – REPLACED/MATCHED ALL BCUZ PATTERN');
+					t.is(req.url, '/', '~> sees correct `url` value – REPLACED/MATCHED ALL BCUZ PATTERN');
+					res.end('rekt');
 				}) // global
 				.get(/^\/movies[/](?<year>[0-9]{4})[/](?<title>[^/]+)/i, (req, res) => {
 					t.pass('runs the /movies/<year>/<title> route');
@@ -661,10 +669,15 @@ if (hasNamedGroups) {
 		t.is(r2.statusCode, 200, '~> received 200 status');
 		t.is(r2.data, 'bye~!', '~> received "bye~!" response');
 
-		console.log('GET /books/narnia?foo');
-		let r3 = await get(uri + '/books/narnia?foo');
+		console.log('GET /books/narnia/comments?foo');
+		let r3 = await get(uri + '/books/narnia/comments?foo');
 		t.is(r3.statusCode, 200, '~> received 200 status');
 		t.is(r3.data, 'cya~!', '~> received "cya~!" response');
+
+		console.log('GET /songs/foo/bar/baz');
+		let r4 = await get(uri + '/songs/foo/bar/baz');
+		t.is(r4.statusCode, 200, '~> received 200 status');
+		t.is(r4.data, 'rekt', '~> received "rekt" response');
 
 		app.server.close();
 	});


### PR DESCRIPTION
Allow Polka application routes to be defined thru RegExp patterns instead of (and in addition to) the current/common string patterns.

This is made possible thru [`trouter@3.1.0`](https://github.com/lukeed/trouter/releases/tag/v3.1.0) and [`regexparam@1.3.0`](https://github.com/lukeed/regexparam/releases/tag/v1.3.0).

***Quick Example:***

```js
polka()
  .use(/^\/movies/i, (req, res, next) => {
    // I will run on any "/movies/*?" url
    // I am equivalent to `use('/movies')`
  })
  .use(/^\/books[/](?<title>[^/]+)/i, (req, res, next) => {
    // I will run on any "/books/foobar/*" url
    // I am equivalent to `use('/books/:title')`
  })
  .get(/^\/movies[/](?<year>[0-9]{4})[/](?<title>[^/]+)/i, (req, res) => {
    // I am equivalent to `get('/movies/:year/:title')`; however,
    // I also will only match if the `:year` segment is 4 digits
  })
  .get(/.*/, (req , res, next) => {
    // I am equivalent to `get('*')`
  })
```
> **Note:** The `RegExp` named capture groups are only [supported in Node 10.x and above](https://node.green/#ES2018-features--RegExp-named-capture-groups)~!

In addition to segment/parameter validation, the named capture groups will also use the names as `req.params` keys. This is identical to its string-pattern counterpart.

Finally, you must be considerate when using a RegExp pattern within a `use()` block – anything the pattern matches will be replaced/trimmed when its handler(s) are run. For example:

```js
// use(/^\/books/, ...)
req.path = "/books/narnia".replace(/^\/books/, '') || '/';
//~> '/narnia'
req.path = "/books/narnia/comments".replace(/^\/books/, '') || '/';
//~> '/narnia/comments'

// use(/books/, ...)
req.path = "/books/narnia".replace(/books/, '') || '/';
// (BAD) ~> '//narnia'
req.path = "/books/narnia/comments".replace(/books/, '') || '/';
// (BAD) ~> '//narnia/comments'

// use(/^\/books.*/, ...)
req.path = "/books/narnia".replace(/^\/books.*/, '') || '/';
// (BAD) ~> '/'
req.path = "/books/narnia/comments".replace(/^\/books.*/, '') || '/';
// (BAD) ~> '/'
```

