### PR TITLE
Fix typecheck for isBuffer in onError handler

### DIFF
--- a/packages/polka/index.js
+++ b/packages/polka/index.js
@@ -19,7 +19,8 @@ function mutate(str, req) {
 
 function onError(err, req, res, next) {
 	let code = (res.statusCode = err.code || err.status || 500);
-	res.end(Buffer.isBuffer(err) && err || err.message || http.STATUS_CODES[code]);
+	if (typeof err === 'string' || Buffer.isBuffer(err)) res.end(err);
+	else res.end(err.message || http.STATUS_CODES[code]);
 }
 
 class Polka extends Router {

--- a/packages/polka/index.js
+++ b/packages/polka/index.js
@@ -19,7 +19,7 @@ function mutate(str, req) {
 
 function onError(err, req, res, next) {
 	let code = (res.statusCode = err.code || err.status || 500);
-	res.end(err.length && err || err.message || http.STATUS_CODES[code]);
+	res.end(Buffer.isBuffer(err) && err || err.message || http.STATUS_CODES[code]);
 }
 
 class Polka extends Router {


### PR DESCRIPTION
Node's [`request.end`](https://nodejs.org/api/http.html#http_response_end_data_encoding_callback) method only allows `Buffer` or `string` arguments, because Polka determines of an object is a buffer by checking if the object has a `length` property, libraries that return objects that have a length property that are not of type Buffer cause a server crash.

I ran into this issue when using [express body-parser](https://github.com/expressjs/body-parser) which returns an error object with a `length` property set if the request exceeds the configured max body size ([see here](https://github.com/expressjs/body-parser#request-entity-too-large)).

This PR uses `Buffer.isBuffer` method to check if the object is a Buffer instead of checking if the object has a `length` property.