### PR TITLE
Fix uncaught error in async middleware

### DIFF
--- a/packages/polka/index.js
+++ b/packages/polka/index.js
@@ -71,8 +71,7 @@ class Polka extends Router {
 
 		let i=0, arr=obj.handlers.concat(this.onNoMatch), len=arr.length;
 		let loop = async () => res.finished || (i < len) && arr[i++](req, res, next);
-		next = next || (err => err ? this.onError(err, req, res, next) : loop().catch(next));
-		next(); // init
+		(next = next || (err => err ? this.onError(err, req, res, next) : loop().catch(next)))(); // init
 	}
 }
 

--- a/packages/polka/index.js
+++ b/packages/polka/index.js
@@ -69,14 +69,10 @@ class Polka extends Router {
 		req.query = info.query || {};
 		req.search = info.search;
 
-		try {
-			let i=0, arr=obj.handlers.concat(this.onNoMatch), len=arr.length;
-			let loop = () => res.finished || (i < len) && arr[i++](req, res, next);
-			next = next || (err => err ? this.onError(err, req, res, next) : loop());
-			loop(); // init
-		} catch (err) {
-			this.onError(err, req, res, next);
-		}
+		let i=0, arr=obj.handlers.concat(this.onNoMatch), len=arr.length;
+		let loop = async () => res.finished || (i < len) && arr[i++](req, res, next);
+		next = next || (err => err ? this.onError(err, req, res, next) : loop().catch(next));
+		next(); // init
 	}
 }
 

--- a/packages/polka/test/index.js
+++ b/packages/polka/test/index.js
@@ -960,6 +960,34 @@ test('(polka) errors – `throw Error`', async t => {
 });
 
 
+test('(polka) errors – `throw Error (async)`', async t => {
+	t.plan(3);
+
+	let app = (
+		polka()
+			.use(async () => {
+				let err = new Error('hello');
+				err.code = 418;
+				throw err;
+			})
+			.get('/', (req, res) => {
+				val = 123; // wont run
+				res.end('OK');
+			})
+	);
+
+	let val = 42;
+	let uri = listen(app);
+	await get(uri).catch(err => {
+		t.is(val, 42, 'exits without running route handler');
+		t.is(err.data, 'hello', '~> received "hello" text');
+		t.is(err.statusCode, 418, '~> received 418 status (custom)');
+	});
+
+	app.server.close();
+});
+
+
 test('(polka) errors – `throw msg`', async t => {
 	t.plan(3);
 

--- a/packages/polka/test/index.js
+++ b/packages/polka/test/index.js
@@ -974,7 +974,7 @@ test('errors – `throw Error` :: async', async () => {
 	);
 
 	let val = 42;
-	let uri = listen(app);
+	let uri = $.listen(app);
 	await get(uri).catch(err => {
 		assert.is(val, 42, 'exits without running route handler');
     assert.is(err.statusCode, 418, '~> received custom status');

--- a/packages/polka/test/index.js
+++ b/packages/polka/test/index.js
@@ -984,6 +984,27 @@ test('errors – `throw Error` :: async', async () => {
 	app.server.close();
 });
 
+test('errors – `throw Error` :: async :: subapp', async () => {
+	let sub = polka().use(async () => {
+		throw new Error('busted');
+	});
+
+	let app = polka().use('/sub', sub, (req, res) => {
+		val = 123; // wont run
+		res.end('OK');
+	});
+
+	let val = 42;
+	let uri = $.listen(app);
+	await get(uri + '/sub/123').catch(err => {
+		assert.is(val, 42, 'exits without running route handler');
+    assert.is(err.statusCode, 500, '~> received default status');
+		assert.is(err.data, 'busted', '~> received "busted" text');
+	});
+
+	app.server.close();
+});
+
 test('errors – `throw msg`', async () => {
 	// t.plan(3);
 


### PR DESCRIPTION
I turned `loop` into an async function to allow it to be caught in `next`. I attempted to test out the performance implication by this change to `async`. This was run on `node v12.16.3` and shows no significant difference but there may be for older versions that I did not get to.

```
hey -z 10s -m GET http://localhost:3000/user/123
// run 3 times, take the last one
```

this pr:

```
Summary:
  Total:	10.0018 secs
  Slowest:	0.0122 secs
  Fastest:	0.0001 secs
  Average:	0.0016 secs
  Requests/sec:	30993.6104
  
  Total data:	2789919 bytes
  Size/request:	9 bytes
```

`polka/next`:

```
Summary:
  Total:	10.0018 secs
  Slowest:	0.0116 secs
  Fastest:	0.0001 secs
  Average:	0.0016 secs
  Requests/sec:	30834.5827
  
  Total data:	2775618 bytes
  Size/request:	9 bytes
```

---

Closes #134 
Closes #164 
