### PR TITLE
Chore: Attach `uvu` test runner

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "bootstrap": "lerna bootstrap --hoist",
     "lint": "eslint packages --env node,es6",
     "pretest": "npm run lint && npm run bootstrap",
-    "test": "tape -r esm packages/*/test/*.js | tap-spec"
+    "test": "uvu -r esm packages test -i util"
   },
   "devDependencies": {
     "bundt": "0.4.0",
@@ -18,8 +18,7 @@
     "esm": "3.2.25",
     "httpie": "1.1.0",
     "lerna": "3.13.4",
-    "tap-spec": "5.0.0",
-    "tape": "4.11.0"
+    "uvu": "0.2.3"
   },
   "eslintConfig": {
     "extends": "eslint:recommended",

--- a/packages/polka/test/index.js
+++ b/packages/polka/test/index.js
@@ -1,62 +1,61 @@
 /* eslint-disable no-console */
 import http from 'http';
+import { test } from 'uvu';
+import * as assert from 'uvu/assert';
 import { get, send, post } from 'httpie';
-import { test, listen } from './util';
 import polka from '../index';
+import * as $ from './util';
 
 const hasNamedGroups = 'groups' in /x/.exec('x');
 const sleep = ms => new Promise(r => setTimeout(r, ms));
 
-test('(polka) exports', t => {
-	t.isFunction(polka, 'exports a function');
-	t.end();
+test('exports', () => {
+	$.isFunction(polka, 'exports a function');
 });
 
 
-test('(polka) internals', t => {
+test('internals', () => {
 	let app = polka();
 	let proto = app.__proto__;
 
-	t.same(app.server, undefined, 'app.server is `undefined` initially');
+	assert.equal(app.server, undefined, 'app.server is `undefined` initially');
 
-	t.isFunction(app.parse, 'app.parse is a function');
-	t.isFunction(app.handler, 'app.handler is a function');
-	t.isFunction(app.onNoMatch, 'app.onNoMatch is a function');
-	t.isFunction(app.onError, 'app.onError is a function');
+	$.isFunction(app.parse, 'app.parse is a function');
+	$.isFunction(app.handler, 'app.handler is a function');
+	$.isFunction(app.onNoMatch, 'app.onNoMatch is a function');
+	$.isFunction(app.onError, 'app.onError is a function');
 
 	['use', 'listen', 'handler'].forEach(k => {
-		t.isFunction(proto[k], `app.${k} is a prototype method`);
+		$.isFunction(proto[k], `app.${k} is a prototype method`);
 	});
 
-	t.isArray(app.routes, 'app.routes is an Array');
-	t.isEmpty(app.routes, '~> is empty');
+	$.isArray(app.routes, 'app.routes is an Array');
+	$.isEmpty(app.routes, '~> is empty');
 
 	['add', 'find'].forEach(k => {
-		t.isFunction(proto[k], `app.${k} is inherited prototype (Trouter)`);
+		$.isFunction(proto[k], `app.${k} is inherited prototype (Trouter)`);
 	});
 
 	['all', 'get', 'head', 'patch', 'options', 'connect', 'delete', 'trace', 'post', 'put'].forEach(k => {
-		t.isFunction(app[k], `app.${k} is inherited method (Trouter)`);
+		$.isFunction(app[k], `app.${k} is inherited method (Trouter)`);
 	});
 
-	t.end();
 });
 
 
-test('(polka) listen', t => {
+test('listen', () => {
 	let app = polka();
 	let out = app.listen();
-	t.same(out, app, 'returns the Polka instance');
-	t.ok(app.server, 'initializes a "server" value');
-	t.true(app.server instanceof http.Server, '~> creates `http.Server` instance');
+	assert.equal(out, app, 'returns the Polka instance');
+	assert.ok(app.server, 'initializes a "server" value');
+	assert.instance(app.server, http.Server, '~> creates `http.Server` instance');
 	app.server.close();
-	t.end();
 });
 
 
 // TODO: Trouter internals & definitions
-test('(polka) basics', t => {
-	t.plan(24);
+test('basics', () => {
+	// t.plan(24);
 
 	let num = 0;
 	let app = polka();
@@ -69,15 +68,15 @@ test('(polka) basics', t => {
 
 	arr.forEach(def => {
 		let [method, pattern, keys] = def;
-		app.add(method, pattern, () => t.pass(`~> matched ${method} ${pattern} route`));
+		app.add(method, pattern, () => assert.ok(`~> matched ${method} ${pattern} route`));
 		let obj = app.routes[num++];
-		t.is(app.routes.length, num, 'added a new `app.routes` entry');
-		t.isObject(obj, '~> entry is an Object');
-		t.isArray(obj.handlers, '~~> entry.handlers is an Array');
-		t.isFunction(obj.handlers[0], '~~> entry.handlers items are Functions');
-		t.true(obj.pattern instanceof RegExp, '~~> entry.pattern is RegExp');
-		t.same(obj.keys, keys, '~~> entry.keys are correct');
-		t.is(obj.method, method, '~~> entry.method matches');
+		assert.is(app.routes.length, num, 'added a new `app.routes` entry');
+		$.isObject(obj, '~> entry is an Object');
+		$.isArray(obj.handlers, '~~> entry.handlers is an Array');
+		$.isFunction(obj.handlers[0], '~~> entry.handlers items are Functions');
+		assert.instance(obj.pattern, RegExp, '~~> entry.pattern is RegExp');
+		assert.equal(obj.keys, keys, '~~> entry.keys are correct');
+		assert.is(obj.method, method, '~~> entry.method matches');
 	});
 
 	arr.forEach(def => {
@@ -87,8 +86,8 @@ test('(polka) basics', t => {
 });
 
 
-test('(polka) variadic handlers', async t => {
-	t.plan(23);
+test('variadic handlers', async () => {
+	// t.plan(23);
 
 	function foo(req, res, next) {
 		req.foo = req.foo || 0;
@@ -103,10 +102,10 @@ test('(polka) variadic handlers', async t => {
 	}
 
 	function onError(err, req, res) {
-		t.pass('2nd "/err" handler threw error!');
-		t.is(err, 'error', '~> receives the "error" message');
-		t.is(req.foo, 500, '~> foo() ran twice');
-		t.is(req.bar, 'bar', '~> bar() ran once');
+		assert.ok('2nd "/err" handler threw error!');
+		assert.is(err, 'error', '~> receives the "error" message');
+		assert.is(req.foo, 500, '~> foo() ran twice');
+		assert.is(req.bar, 'bar', '~> bar() ran once');
 		res.statusCode = 400;
 		res.end('error');
 	}
@@ -118,54 +117,54 @@ test('(polka) variadic handlers', async t => {
 	let app = (
 		polka({ onError }).use(foo, bar)
 			.get('/one', foo, bar, (req, res) => {
-				t.pass('3rd "/one" handler');
-				t.is(req.foo, 500, '~> foo() ran twice');
-				t.is(req.bar, 'barbar', '~> bar() ran twice');
+				assert.ok('3rd "/one" handler');
+				assert.is(req.foo, 500, '~> foo() ran twice');
+				assert.is(req.bar, 'barbar', '~> bar() ran twice');
 				res.end('one');
 			})
 			.get('/two', foo, (req, res, next) => {
-				t.pass('2nd "/two" handler')
-				t.is(req.foo, 500, '~> foo() ran twice');
-				t.is(req.bar, 'bar', '~> bar() ran once');
+				assert.ok('2nd "/two" handler')
+				assert.is(req.foo, 500, '~> foo() ran twice');
+				assert.is(req.bar, 'bar', '~> bar() ran once');
 				req.hello = 'world';
 				next();
 			}, (req, res) => {
-				t.pass('3rd "/two" handler')
-				t.is(req.hello, 'world', '~> preserves route handler order');
-				t.is(req.foo, 500, '~> original `req` object all the way');
+				assert.ok('3rd "/two" handler')
+				assert.is(req.hello, 'world', '~> preserves route handler order');
+				assert.is(req.foo, 500, '~> original `req` object all the way');
 				res.end('two');
 			})
 			.get('/err', foo, toError, (req, res) => {
-				t.pass('SHOULD NOT RUN');
+				assert.ok('SHOULD NOT RUN');
 				res.end('wut');
 			})
 	);
 
-	t.is(app.routes.length, 4, 'added 3 routes in total'); // use(foo, bar) ~> 1 declaration
-	t.is(app.find('GET', '/one').handlers.length, 5, '~> has 5 handlers for "GET /one" route');
-	t.is(app.find('GET', '/two').handlers.length, 5, '~> has 5 handlers for "GET /two" route');
-	t.is(app.find('GET', '/err').handlers.length, 5, '~> has 5 handlers for "GET /err" route');
+	assert.is(app.routes.length, 4, 'added 3 routes in total'); // use(foo, bar) ~> 1 declaration
+	assert.is(app.find('GET', '/one').handlers.length, 5, '~> has 5 handlers for "GET /one" route');
+	assert.is(app.find('GET', '/two').handlers.length, 5, '~> has 5 handlers for "GET /two" route');
+	assert.is(app.find('GET', '/err').handlers.length, 5, '~> has 5 handlers for "GET /err" route');
 
-	let uri = listen(app);
+	let uri = $.listen(app);
 	let r = await get(uri + '/one');
-	t.is(r.statusCode, 200, '~> received 200 status');
-	t.is(r.data, 'one', '~> received "one" response');
+	assert.is(r.statusCode, 200, '~> received 200 status');
+	assert.is(r.data, 'one', '~> received "one" response');
 
 	r = await get(uri + '/two');
-	t.is(r.statusCode, 200, '~> received 200 status');
-	t.is(r.data, 'two', '~> received "two" response');
+	assert.is(r.statusCode, 200, '~> received 200 status');
+	assert.is(r.data, 'two', '~> received "two" response');
 
 	await get(uri + '/err').catch(err => {
-		t.is(err.statusCode, 400, '~> received 400 status');
-		t.is(err.data, 'error', '~> received "error" response');
+		assert.is(err.statusCode, 400, '~> received 400 status');
+		assert.is(err.data, 'error', '~> received "error" response');
 	});
 
 	app.server.close();
 });
 
 
-test('(polka) middleware', async t => {
-	t.plan(21);
+test('middleware', async () => {
+	// t.plan(21);
 
 	let app = (
 		polka()
@@ -178,63 +177,63 @@ test('(polka) middleware', async t => {
 				next();
 			})
 			.use('/about', (req, res) => {
-				t.is(req.one, 'hello', '~> sub-mware runs after first global middleware');
-				t.is(req.two, 'world', '~> sub-mware runs after second global middleware');
+				assert.is(req.one, 'hello', '~> sub-mware runs after first global middleware');
+				assert.is(req.two, 'world', '~> sub-mware runs after second global middleware');
 				res.end('About');
 			})
 			.use('/subgroup', (req, res, next) => {
 				req.subgroup = true;
-				t.is(req.one, 'hello', '~> sub-mware runs after first global middleware');
-				t.is(req.two, 'world', '~> sub-mware runs after second global middleware');
+				assert.is(req.one, 'hello', '~> sub-mware runs after first global middleware');
+				assert.is(req.two, 'world', '~> sub-mware runs after second global middleware');
 				next();
 			})
 			.post('/subgroup', (req, res) => {
-				t.is(req.subgroup, true, '~~> POST /subgroup ran after its shared middleware');
+				assert.is(req.subgroup, true, '~~> POST /subgroup ran after its shared middleware');
 				res.end('POST /subgroup');
 			})
 			.get('/subgroup/foo', (req, res) => {
-				t.is(req.subgroup, true, '~~> GET /subgroup/foo ran after its shared middleware');
+				assert.is(req.subgroup, true, '~~> GET /subgroup/foo ran after its shared middleware');
 				res.end('GET /subgroup/foo');
 			})
 			.get('/', (req, res) => {
-				t.pass('~> matches the GET(/) route');
-				t.is(req.one, 'hello', '~> route handler runs after first middleware');
-				t.is(req.two, 'world', '~> route handler runs after both middlewares!');
+				assert.ok('~> matches the GET(/) route');
+				assert.is(req.one, 'hello', '~> route handler runs after first middleware');
+				assert.is(req.two, 'world', '~> route handler runs after both middlewares!');
 				res.setHeader('x-type', 'text/foo');
 				res.end('Hello');
 			})
 	);
 
-	t.is(app.routes.length, 7, 'added 7 routes in total');
+	assert.is(app.routes.length, 7, 'added 7 routes in total');
 
-	let uri = listen(app);
-	console.log('GET /');
+	let uri = $.listen(app);
+	// console.log('GET /');
 	let r = await get(uri);
-	t.is(r.statusCode, 200, '~> received 200 status');
-	t.is(r.data, 'Hello', '~> received "Hello" response');
-	t.is(r.headers['x-type'], 'text/foo', '~> received custom header');
+	assert.is(r.statusCode, 200, '~> received 200 status');
+	assert.is(r.data, 'Hello', '~> received "Hello" response');
+	assert.is(r.headers['x-type'], 'text/foo', '~> received custom header');
 
-	console.log('GET /about');
+	// console.log('GET /about');
 	r = await get(uri + '/about');
-	t.is(r.statusCode, 200, '~> received 200 status');
-	t.is(r.data, 'About', '~> received "About" response');
+	assert.is(r.statusCode, 200, '~> received 200 status');
+	assert.is(r.data, 'About', '~> received "About" response');
 
-	console.log('POST /subgroup');
+	// console.log('POST /subgroup');
 	r = await post(uri + '/subgroup');
-	t.is(r.statusCode, 200, '~> received 200 status');
-	t.is(r.data, 'POST /subgroup', '~> received "POST /subgroup" response');
+	assert.is(r.statusCode, 200, '~> received 200 status');
+	assert.is(r.data, 'POST /subgroup', '~> received "POST /subgroup" response');
 
-	console.log('GET /subgroup/foo');
+	// console.log('GET /subgroup/foo');
 	r = await get(uri + '/subgroup/foo');
-	t.is(r.statusCode, 200, '~> received 200 status');
-	t.is(r.data, 'GET /subgroup/foo', '~> received "GET /subgroup/foo" response');
+	assert.is(r.statusCode, 200, '~> received 200 status');
+	assert.is(r.data, 'GET /subgroup/foo', '~> received "GET /subgroup/foo" response');
 
 	app.server.close();
 });
 
 
-test('(polka) middleware – async', async t => {
-	t.plan(7);
+test('middleware – async', async () => {
+	// t.plan(7);
 
 	let app = (
 		polka().use(async (req, res, next) => {
@@ -244,98 +243,98 @@ test('(polka) middleware – async', async t => {
 		}).use((req, res, next) => {
 			sleep(1).then(() => { req.bar=456 }).then(next);
 		}).get('/', (req, res) => {
-			t.pass('~> matches the GET(/) route');
-			t.is(req.foo, 123, '~> route handler runs after first middleware');
-			t.is(req.bar, 456, '~> route handler runs after both middlewares!');
+			assert.ok('~> matches the GET(/) route');
+			assert.is(req.foo, 123, '~> route handler runs after first middleware');
+			assert.is(req.bar, 456, '~> route handler runs after both middlewares!');
 			res.setHeader('x-type', 'text/foo');
 			res.end('Hello');
 		})
 	);
 
-	t.is(app.routes.length, 3, 'added 3 routes in total');
+	assert.is(app.routes.length, 3, 'added 3 routes in total');
 
-	let uri = listen(app);
+	let uri = $.listen(app);
 
 	let r = await get(uri);
-	t.is(r.statusCode, 200, '~> received 200 status');
-	t.is(r.data, 'Hello', '~> received "Hello" response');
-	t.is(r.headers['x-type'], 'text/foo', '~> received custom header');
+	assert.is(r.statusCode, 200, '~> received 200 status');
+	assert.is(r.data, 'Hello', '~> received "Hello" response');
+	assert.is(r.headers['x-type'], 'text/foo', '~> received custom header');
 
 	app.server.close();
 });
 
 
-test('(polka) middleware – sequencing', async t => {
-	t.plan(15);
+test('middleware – sequencing', async () => {
+	// t.plan(15);
 
 	function foo(req, res, next) {
-		t.is(req.val = 1, 1, '~> foo saw 1');
+		assert.is(req.val = 1, 1, '~> foo saw 1');
 		next();
 	}
 
 	function bar(req, res, next) {
-		t.is(++req.val, 2, '~> bar saw 2');
+		assert.is(++req.val, 2, '~> bar saw 2');
 		next();
 	}
 
 	let app = (
 		polka()
 			.get('/foo', (req, res) => {
-				t.is(req.val, undefined, '~> get("/foo") ran before any mware');
+				assert.is(req.val, undefined, '~> get("/foo") ran before any mware');
 				res.end('foo');
 			})
 			.use(foo, bar)
 			.get('/sub', (req, res) => {
-				t.is(++req.val, 3, '~> get("/sub") saw 3');
+				assert.is(++req.val, 3, '~> get("/sub") saw 3');
 				res.end('ran=' + req.val);
 			})
 			.use('/sub', (req, res, next) => {
-				t.is(++req.val, 3, '~> use("/sub") saw 3');
+				assert.is(++req.val, 3, '~> use("/sub") saw 3');
 				next();
 			})
 			.post('*', (req, res, next) => {
-				t.is(++req.val, 4, '~> post("*") saw 4');
+				assert.is(++req.val, 4, '~> post("*") saw 4');
 				next();
 			})
 			.post('/sub', (req, res) => {
-				t.is(++req.val, 5, '~> post("/sub") saw 5');
+				assert.is(++req.val, 5, '~> post("/sub") saw 5');
 				res.end('ran=' + req.val);
 			})
 	);
 
-	let uri = listen(app);
+	let uri = $.listen(app);
 
-	console.log('GET "/sub"');
+	// console.log('GET "/sub"');
 	let r1 = await get(uri + '/sub');
-	t.is(r1.statusCode, 200, '~> received 200 status');
-	t.is(r1.data, 'ran=3', '~> received "ran=3" response');
+	assert.is(r1.statusCode, 200, '~> received 200 status');
+	assert.is(r1.data, 'ran=3', '~> received "ran=3" response');
 
-	console.log('POST "/sub"');
+	// console.log('POST "/sub"');
 	let r2 = await post(uri + '/sub');
-	t.is(r2.statusCode, 200, '~> received 200 status');
-	t.is(r2.data, 'ran=5', '~> received "ran=5" response');
+	assert.is(r2.statusCode, 200, '~> received 200 status');
+	assert.is(r2.data, 'ran=5', '~> received "ran=5" response');
 
-	console.log('GET "/foo"');
+	// console.log('GET "/foo"');
 	let r3 = await get(uri + '/foo');
-	t.is(r3.statusCode, 200, '~> received 200 status');
-	t.is(r3.data, 'foo', '~> received "foo" response');
+	assert.is(r3.statusCode, 200, '~> received 200 status');
+	assert.is(r3.data, 'foo', '~> received "foo" response');
 
 	app.server.close();
 });
 
 
-test('(polka) middleware - use(subapp)', async t => {
-	t.plan(21);
+test('middleware - use(subapp)', async () => {
+	// t.plan(21);
 
 	function foo(req, res, next) {
-		t.is(req.main, true, '~> FOO ran after MAIN');
+		assert.is(req.main, true, '~> FOO ran after MAIN');
 		req.foo = true;
 		next();
 	}
 
 	function bar(req, res, next) {
-		t.is(req.main, true, '~> BAR ran after MAIN');
-		t.is(req.foo, true, '~> BAR ran after FOO');
+		assert.is(req.main, true, '~> BAR ran after MAIN');
+		assert.is(req.foo, true, '~> BAR ran after FOO');
 		req.bar = true;
 		next();
 	}
@@ -344,18 +343,18 @@ test('(polka) middleware - use(subapp)', async t => {
 		polka()
 			.use(foo, bar)
 			.use((req, res, next) => {
-				t.is(req.main, true, '~> SUB ran after MAIN');
-				t.is(req.foo, true, '~> SUB ran after FOO');
-				t.is(req.bar, true, '~> SUB ran after BAR');
+				assert.is(req.main, true, '~> SUB ran after MAIN');
+				assert.is(req.foo, true, '~> SUB ran after FOO');
+				assert.is(req.bar, true, '~> SUB ran after BAR');
 				req.sub = true;
 				next();
 			})
 			.get('/item', (req, res) => {
-				t.pass('~> HANDLER for sub("/item") ran');
-				t.is(req.main, true, '~> HANDLER ran after MAIN');
-				t.is(req.foo, true, '~> HANDLER ran after FOO');
-				t.is(req.bar, true, '~> HANDLER ran after BAR');
-				t.is(req.sub, true, '~> HANDLER ran after SUB');
+				assert.ok('~> HANDLER for sub("/item") ran');
+				assert.is(req.main, true, '~> HANDLER ran after MAIN');
+				assert.is(req.foo, true, '~> HANDLER ran after FOO');
+				assert.is(req.bar, true, '~> HANDLER ran after BAR');
+				assert.is(req.sub, true, '~> HANDLER ran after SUB');
 				res.end('item');
 			})
 	);
@@ -370,37 +369,37 @@ test('(polka) middleware - use(subapp)', async t => {
 			.use(sub)
 	);
 
-	let uri = listen(main);
+	let uri = $.listen(main);
 
-	console.log('GET "/item"');
+	// console.log('GET "/item"');
 	// `sub` has the "/item" route
 	let res = await get(uri + '/item'); // +10
-	t.is(res.statusCode, 200, '~> received 200 status');
-	t.is(res.data, 'item', '~> received "item" response');
+	assert.is(res.statusCode, 200, '~> received 200 status');
+	assert.is(res.data, 'item', '~> received "item" response');
 
-	console.log('GET "/unknown"');
+	// console.log('GET "/unknown"');
 	// 404 from `sub` application, no route
 	await get(uri + '/unknown').catch(err => { // +6
-		t.is(err.statusCode, 404, '~> received 404 status');
-		t.is(err.data, 'Not Found', '~> received "Not Found" response');
+		assert.is(err.statusCode, 404, '~> received 404 status');
+		assert.is(err.data, 'Not Found', '~> received "Not Found" response');
 	});
 
 	main.server.close();
 });
 
 
-test('(polka) middleware - use(mware, subapp)', async t => {
-	t.plan(21);
+test('middleware - use(mware, subapp)', async () => {
+	// t.plan(21);
 
 	function foo(req, res, next) {
-		t.is(req.main, true, '~> FOO ran after MAIN');
+		assert.is(req.main, true, '~> FOO ran after MAIN');
 		req.foo = true;
 		next();
 	}
 
 	function bar(req, res, next) {
-		t.is(req.main, true, '~> BAR ran after MAIN');
-		t.is(req.foo, true, '~> BAR ran after FOO');
+		assert.is(req.main, true, '~> BAR ran after MAIN');
+		assert.is(req.foo, true, '~> BAR ran after FOO');
 		req.bar = true;
 		next();
 	}
@@ -409,18 +408,18 @@ test('(polka) middleware - use(mware, subapp)', async t => {
 		polka()
 			.use(bar)
 			.use((req, res, next) => {
-				t.is(req.main, true, '~> SUB ran after MAIN');
-				t.is(req.foo, true, '~> SUB ran after FOO');
-				t.is(req.bar, true, '~> SUB ran after BAR');
+				assert.is(req.main, true, '~> SUB ran after MAIN');
+				assert.is(req.foo, true, '~> SUB ran after FOO');
+				assert.is(req.bar, true, '~> SUB ran after BAR');
 				req.sub = true;
 				next();
 			})
 			.get('/item', (req, res) => {
-				t.pass('~> HANDLER for sub("/item") ran');
-				t.is(req.main, true, '~> HANDLER ran after MAIN');
-				t.is(req.foo, true, '~> HANDLER ran after FOO');
-				t.is(req.bar, true, '~> HANDLER ran after BAR');
-				t.is(req.sub, true, '~> HANDLER ran after SUB');
+				assert.ok('~> HANDLER for sub("/item") ran');
+				assert.is(req.main, true, '~> HANDLER ran after MAIN');
+				assert.is(req.foo, true, '~> HANDLER ran after FOO');
+				assert.is(req.bar, true, '~> HANDLER ran after BAR');
+				assert.is(req.sub, true, '~> HANDLER ran after SUB');
 				res.end('item');
 			})
 	);
@@ -435,37 +434,37 @@ test('(polka) middleware - use(mware, subapp)', async t => {
 			.use(foo, sub)
 	);
 
-	let uri = listen(main);
+	let uri = $.listen(main);
 
-	console.log('GET "/item"');
+	// console.log('GET "/item"');
 	// `sub` has the "/item" route
 	let res = await get(uri + '/item'); // +10
-	t.is(res.statusCode, 200, '~> received 200 status');
-	t.is(res.data, 'item', '~> received "item" response');
+	assert.is(res.statusCode, 200, '~> received 200 status');
+	assert.is(res.data, 'item', '~> received "item" response');
 
-	console.log('GET "/unknown"');
+	// console.log('GET "/unknown"');
 	// 404 from `sub` application, no route
 	await get(uri + '/unknown').catch(err => { // +6
-		t.is(err.statusCode, 404, '~> received 404 status');
-		t.is(err.data, 'Not Found', '~> received "Not Found" response');
+		assert.is(err.statusCode, 404, '~> received 404 status');
+		assert.is(err.data, 'Not Found', '~> received "Not Found" response');
 	});
 
 	main.server.close();
 });
 
 
-test('(polka) middleware - use("/", subapp)', async t => {
-	t.plan(21);
+test('middleware - use("/", subapp)', async () => {
+	// t.plan(21);
 
 	function foo(req, res, next) {
-		t.is(req.main, true, '~> FOO ran after MAIN');
+		assert.is(req.main, true, '~> FOO ran after MAIN');
 		req.foo = true;
 		next();
 	}
 
 	function bar(req, res, next) {
-		t.is(req.main, true, '~> BAR ran after MAIN');
-		t.is(req.foo, true, '~> BAR ran after FOO');
+		assert.is(req.main, true, '~> BAR ran after MAIN');
+		assert.is(req.foo, true, '~> BAR ran after FOO');
 		req.bar = true;
 		next();
 	}
@@ -474,18 +473,18 @@ test('(polka) middleware - use("/", subapp)', async t => {
 		polka()
 			.use(bar)
 			.use((req, res, next) => {
-				t.is(req.main, true, '~> SUB ran after MAIN');
-				t.is(req.foo, true, '~> SUB ran after FOO');
-				t.is(req.bar, true, '~> SUB ran after BAR');
+				assert.is(req.main, true, '~> SUB ran after MAIN');
+				assert.is(req.foo, true, '~> SUB ran after FOO');
+				assert.is(req.bar, true, '~> SUB ran after BAR');
 				req.sub = true;
 				next();
 			})
 			.get('/item', (req, res) => {
-				t.pass('~> HANDLER for sub("/item") ran');
-				t.is(req.main, true, '~> HANDLER ran after MAIN');
-				t.is(req.foo, true, '~> HANDLER ran after FOO');
-				t.is(req.bar, true, '~> HANDLER ran after BAR');
-				t.is(req.sub, true, '~> HANDLER ran after SUB');
+				assert.ok('~> HANDLER for sub("/item") ran');
+				assert.is(req.main, true, '~> HANDLER ran after MAIN');
+				assert.is(req.foo, true, '~> HANDLER ran after FOO');
+				assert.is(req.bar, true, '~> HANDLER ran after BAR');
+				assert.is(req.sub, true, '~> HANDLER ran after SUB');
 				res.end('item');
 			})
 	);
@@ -500,35 +499,35 @@ test('(polka) middleware - use("/", subapp)', async t => {
 			.use('/', foo, sub)
 	);
 
-	let uri = listen(main);
+	let uri = $.listen(main);
 
-	console.log('GET "/item"');
+	// console.log('GET "/item"');
 	// `sub` has the "/item" route
 	let res = await get(uri + '/item'); // +10
-	t.is(res.statusCode, 200, '~> received 200 status');
-	t.is(res.data, 'item', '~> received "item" response');
+	assert.is(res.statusCode, 200, '~> received 200 status');
+	assert.is(res.data, 'item', '~> received "item" response');
 
-	console.log('GET "/unknown"');
+	// console.log('GET "/unknown"');
 	// 404 from `sub` application, no route
 	await get(uri + '/unknown').catch(err => { // +6
-		t.is(err.statusCode, 404, '~> received 404 status');
-		t.is(err.data, 'Not Found', '~> received "Not Found" response');
+		assert.is(err.statusCode, 404, '~> received 404 status');
+		assert.is(err.data, 'Not Found', '~> received "Not Found" response');
 	});
 
 	main.server.close();
 });
 
 
-test('(polka) middleware – use("foo/bar")', async t => {
-	t.plan(16);
+test('middleware – use("foo/bar")', async () => {
+	// t.plan(16);
 
 	function foo(req, res, next) {
-		t.is(req.val = 1, 1, '~> foo saw 1');
+		assert.is(req.val = 1, 1, '~> foo saw 1');
 		next();
 	}
 
 	function bar(req, res, next) {
-		t.is(++req.val, 2, '~> bar saw 2');
+		assert.is(++req.val, 2, '~> bar saw 2');
 		next();
 	}
 
@@ -536,53 +535,53 @@ test('(polka) middleware – use("foo/bar")', async t => {
 		polka()
 			.use(foo, bar)
 			.get('/api/v1', (req, res) => {
-				t.is(++req.val, 3, '~> get("/api/v1") saw 3');
-				t.is(req.url, '/api/v1', '~> get("/api/v1") had correct url'); // 1
+				assert.is(++req.val, 3, '~> get("/api/v1") saw 3');
+				assert.is(req.url, '/api/v1', '~> get("/api/v1") had correct url'); // 1
 				res.end('ran=' + req.val);
 			})
 			.use('/api/v1', (req, res, next) => {
-				t.is(++req.val, 3, '~> use("/api/v1") saw 3');
-				t.is(req.url, '/hello', '~> use("/api/v1") had correct url'); // 1
+				assert.is(++req.val, 3, '~> use("/api/v1") saw 3');
+				assert.is(req.url, '/hello', '~> use("/api/v1") had correct url'); // 1
 				next();
 			})
 			.post('*', (req, res, next) => {
-				t.is(++req.val, 4, '~> post("*") saw 4');
-				t.is(req.url, '/api/v1/hello', '~> post("*") had correct url'); //
+				assert.is(++req.val, 4, '~> post("*") saw 4');
+				assert.is(req.url, '/api/v1/hello', '~> post("*") had correct url'); //
 				next();
 			})
 			.post('/api/v1/hello', (req, res) => {
-				t.is(++req.val, 5, '~> post("/api/v1/hello") saw 5');
-				t.is(req.url, '/api/v1/hello', '~> post("/api/v1/hello") had correct url');
+				assert.is(++req.val, 5, '~> post("/api/v1/hello") saw 5');
+				assert.is(req.url, '/api/v1/hello', '~> post("/api/v1/hello") had correct url');
 				res.end('ran=' + req.val);
 			})
 	);
 
-	let uri = listen(app);
+	let uri = $.listen(app);
 
-	console.log('GET "/api/v1"');
+	// console.log('GET "/api/v1"');
 	let r1 = await get(uri + '/api/v1');
-	t.is(r1.statusCode, 200, '~> received 200 status');
-	t.is(r1.data, 'ran=3', '~> received "ran=3" response');
+	assert.is(r1.statusCode, 200, '~> received 200 status');
+	assert.is(r1.data, 'ran=3', '~> received "ran=3" response');
 
-	console.log('POST "/api/v1/hello"');
+	// console.log('POST "/api/v1/hello"');
 	let r2 = await post(uri + '/api/v1/hello');
-	t.is(r2.statusCode, 200, '~> received 200 status');
-	t.is(r2.data, 'ran=5', '~> received "ran=5" response');
+	assert.is(r2.statusCode, 200, '~> received 200 status');
+	assert.is(r2.data, 'ran=5', '~> received "ran=5" response');
 
 	app.server.close();
 });
 
 
-test('(polka) middleware – use("foo/:bar")', async t => {
-	t.plan(20);
+test('middleware – use("foo/:bar")', async () => {
+	// t.plan(20);
 
 	function foo(req, res, next) {
-		t.is(req.val = 1, 1, '~> foo saw 1');
+		assert.is(req.val = 1, 1, '~> foo saw 1');
 		next();
 	}
 
 	function bar(req, res, next) {
-		t.is(++req.val, 2, '~> bar saw 2');
+		assert.is(++req.val, 2, '~> bar saw 2');
 		next();
 	}
 
@@ -590,49 +589,49 @@ test('(polka) middleware – use("foo/:bar")', async t => {
 		polka()
 			.use(foo, bar)
 			.get('/api/:version', (req, res) => {
-				t.is(++req.val, 3, '~> get("/api/:version") saw 3');
-				t.is(req.url, '/api/v1', '~> get("/api/:version") had correct url'); // 1
-				t.is(req.params.version, 'v1', '~> req.params.version correct');
+				assert.is(++req.val, 3, '~> get("/api/:version") saw 3');
+				assert.is(req.url, '/api/v1', '~> get("/api/:version") had correct url'); // 1
+				assert.is(req.params.version, 'v1', '~> req.params.version correct');
 				res.end('ran=' + req.val);
 			})
 			.use('/api/:version', (req, res, next) => {
-				t.is(++req.val, 3, '~> use("/api/:version") saw 3');
-				t.is(req.url, '/', '~> use("/api/:version") had correct url'); // 1
-				t.is(req.params.version, 'v2', '~> req.params.version correct');
+				assert.is(++req.val, 3, '~> use("/api/:version") saw 3');
+				assert.is(req.url, '/', '~> use("/api/:version") had correct url'); // 1
+				assert.is(req.params.version, 'v2', '~> req.params.version correct');
 				next();
 			})
 			.post('*', (req, res, next) => {
-				t.is(++req.val, 4, '~> post("*") saw 4');
-				t.is(req.url, '/api/v2/hello', '~> post("*") had correct url');
-				t.is(req.params.version, 'v2', '~> req.params.version correct');
+				assert.is(++req.val, 4, '~> post("*") saw 4');
+				assert.is(req.url, '/api/v2/hello', '~> post("*") had correct url');
+				assert.is(req.params.version, 'v2', '~> req.params.version correct');
 				next();
 			})
 			.post('/api/:version/hello', (req, res) => {
-				t.is(++req.val, 5, '~> post("/api/:version/hello") saw 5');
-				t.is(req.url, '/api/v2/hello', '~> post("/api/:version/hello") had correct url');
-				t.is(req.params.version, 'v2', '~> req.params.version correct');
+				assert.is(++req.val, 5, '~> post("/api/:version/hello") saw 5');
+				assert.is(req.url, '/api/v2/hello', '~> post("/api/:version/hello") had correct url');
+				assert.is(req.params.version, 'v2', '~> req.params.version correct');
 				res.end('ran=' + req.val);
 			})
 	);
 
-	let uri = listen(app);
+	let uri = $.listen(app);
 
-	console.log('GET "/api/v1"');
+	// console.log('GET "/api/v1"');
 	let r1 = await get(uri + '/api/v1');
-	t.is(r1.statusCode, 200, '~> received 200 status');
-	t.is(r1.data, 'ran=3', '~> received "ran=3" response');
+	assert.is(r1.statusCode, 200, '~> received 200 status');
+	assert.is(r1.data, 'ran=3', '~> received "ran=3" response');
 
-	console.log('POST "/api/v2/hello"');
+	// console.log('POST "/api/v2/hello"');
 	let r2 = await post(uri + '/api/v2/hello');
-	t.is(r2.statusCode, 200, '~> received 200 status');
-	t.is(r2.data, 'ran=5', '~> received "ran=5" response');
+	assert.is(r2.statusCode, 200, '~> received 200 status');
+	assert.is(r2.data, 'ran=5', '~> received "ran=5" response');
 
 	app.server.close();
 });
 
 
-test('(polka) middleware – originalUrl + mutation', async t => {
-	t.plan(42);
+test('middleware – originalUrl + mutation', async () => {
+	// t.plan(42);
 
 	let chk = false;
 	let aaa = (req, res, next) => (req.aaa='aaa',next());
@@ -640,8 +639,8 @@ test('(polka) middleware – originalUrl + mutation', async t => {
 	let bar = (req, res, next) => (req.bar='bar',next());
 	let ccc = (req, res, next) => {
 		if (chk) { // runs 2x
-			t.true(req.url.includes('/foo'), 'defers URL mutation until after global');
-			t.true(req.path.includes('/foo'), 'defers PATH mutation until after global');
+			assert.ok(req.url.includes('/foo'), 'defers URL mutation until after global');
+			assert.ok(req.path.includes('/foo'), 'defers PATH mutation until after global');
 			chk = false;
 		}
 		next();
@@ -652,104 +651,104 @@ test('(polka) middleware – originalUrl + mutation', async t => {
 			.use(aaa, bbb, ccc) // globals
 			.use('foo', (req, res) => {
 				// all runs 2 times
-				t.pass('runs the base middleware for: foo');
-				t.is(req.aaa, 'aaa', '~> runs after `aaa` global middleware');
-				t.is(req.bbb, 'bbb', '~> runs after `bbb` global middleware');
-				t.false(req.url.includes('foo'), '~> strips "foo" base from `req.url`');
-				t.false(req.path.includes('foo'), '~> strips "foo" base from `req.path`');
-				t.ok(req.originalUrl.includes('foo'), '~> keeps "foo" base within `req.originalUrl`');
+				assert.ok('runs the base middleware for: foo');
+				assert.is(req.aaa, 'aaa', '~> runs after `aaa` global middleware');
+				assert.is(req.bbb, 'bbb', '~> runs after `bbb` global middleware');
+				assert.not(req.url.includes('foo'), '~> strips "foo" base from `req.url`');
+				assert.not(req.path.includes('foo'), '~> strips "foo" base from `req.path`');
+				assert.ok(req.originalUrl.includes('foo'), '~> keeps "foo" base within `req.originalUrl`');
 				res.end('hello from foo');
 			})
 			.use('bar', bar, (req, res) => {
-				t.pass('runs the base middleware for: bar');
-				t.is(req.aaa, 'aaa', '~> runs after `aaa` global middleware');
-				t.is(req.bbb, 'bbb', '~> runs after `bbb` global middleware');
-				t.is(req.bar, 'bar', '~> runs after `bar` SELF-GROUPED middleware');
-				t.false(req.url.includes('bar'), '~> strips "bar" base from `req.url`');
-				t.false(req.path.includes('bar'), '~> strips "bar" base from `req.path`');
-				t.ok(req.originalUrl.includes('bar'), '~> keeps "bar" base within `req.originalUrl`');
-				t.is(req.path, '/hello', '~> matches expected `req.path` value');
+				assert.ok('runs the base middleware for: bar');
+				assert.is(req.aaa, 'aaa', '~> runs after `aaa` global middleware');
+				assert.is(req.bbb, 'bbb', '~> runs after `bbb` global middleware');
+				assert.is(req.bar, 'bar', '~> runs after `bar` SELF-GROUPED middleware');
+				assert.not(req.url.includes('bar'), '~> strips "bar" base from `req.url`');
+				assert.not(req.path.includes('bar'), '~> strips "bar" base from `req.path`');
+				assert.ok(req.originalUrl.includes('bar'), '~> keeps "bar" base within `req.originalUrl`');
+				assert.is(req.path, '/hello', '~> matches expected `req.path` value');
 				res.end('hello from bar');
 			})
 			.get('/', (req, res) => {
-				t.pass('runs the MAIN app handler for GET /');
-				t.is(req.aaa, 'aaa', '~> runs after `aaa` global middleware');
-				t.is(req.bbb, 'bbb', '~> runs after `bbb` global middleware');
+				assert.ok('runs the MAIN app handler for GET /');
+				assert.is(req.aaa, 'aaa', '~> runs after `aaa` global middleware');
+				assert.is(req.bbb, 'bbb', '~> runs after `bbb` global middleware');
 				res.end('hello from main');
 			})
 	);
 
-	t.is(app.routes.length, 4, 'added 4 routes in total');
+	assert.is(app.routes.length, 4, 'added 4 routes in total');
 	// .use('/any') ~> adds 1 BEFORE & 1 AFTER middleware (prep + cleanup)
-	t.is(app.find('GET', '/foo').handlers.length, 6, '~> has 6 handlers for "GET /foo" route');
-	t.is(app.find('POST', '/foo').handlers.length, 6, '~> has 6 handlers for "POST /foo" route');
-	t.is(app.find('GET', '/bar').handlers.length, 7, '~> has 7 handlers for "GET /bar" route');
-	t.is(app.find('POST', '/bar').handlers.length, 7, '~> has 7 handlers for "POST /bar" route');
+	assert.is(app.find('GET', '/foo').handlers.length, 6, '~> has 6 handlers for "GET /foo" route');
+	assert.is(app.find('POST', '/foo').handlers.length, 6, '~> has 6 handlers for "POST /foo" route');
+	assert.is(app.find('GET', '/bar').handlers.length, 7, '~> has 7 handlers for "GET /bar" route');
+	assert.is(app.find('POST', '/bar').handlers.length, 7, '~> has 7 handlers for "POST /bar" route');
 
-	let uri = listen(app);
+	let uri = $.listen(app);
 
-	console.log('GET /');
+	// console.log('GET /');
 	let r1 = await get(uri);
-	t.is(r1.statusCode, 200, '~> received 200 status');
-	t.is(r1.data, 'hello from main', '~> received "hello from main" response');
+	assert.is(r1.statusCode, 200, '~> received 200 status');
+	assert.is(r1.data, 'hello from main', '~> received "hello from main" response');
 
 	chk = true;
-	console.log('GET /foo');
+	// console.log('GET /foo');
 	let r2 = await get(`${uri}/foo`);
-	t.is(r2.statusCode, 200, '~> received 200 status');
-	t.is(r2.data, 'hello from foo', '~> received "hello from foo" response');
+	assert.is(r2.statusCode, 200, '~> received 200 status');
+	assert.is(r2.data, 'hello from foo', '~> received "hello from foo" response');
 
 	chk = true;
-	console.log('POST /foo/items?this=123');
+	// console.log('POST /foo/items?this=123');
 	let r3 = await post(`${uri}/foo/items?this=123`);
-	t.is(r3.statusCode, 200, '~> received 200 status');
-	t.is(r3.data, 'hello from foo', '~> received "hello from foo" response');
+	assert.is(r3.statusCode, 200, '~> received 200 status');
+	assert.is(r3.data, 'hello from foo', '~> received "hello from foo" response');
 
-	console.log('GET /bar/hello');
+	// console.log('GET /bar/hello');
 	let r4 = await get(`${uri}/bar/hello`);
-	t.is(r4.statusCode, 200, '~> received 200 status');
-	t.is(r4.data, 'hello from bar', '~> received "hello from bar" response');
+	assert.is(r4.statusCode, 200, '~> received 200 status');
+	assert.is(r4.data, 'hello from bar', '~> received "hello from bar" response');
 
-	console.log('GET /foobar');
+	// console.log('GET /foobar');
 	await get(`${uri}/foobar`).catch(err => {
-		t.is(err.statusCode, 404, '~> received 404 status');
-		t.is(err.data, 'Not Found', '~> received "Not Found" response');
+		assert.is(err.statusCode, 404, '~> received 404 status');
+		assert.is(err.data, 'Not Found', '~> received "Not Found" response');
 	});
 
 	app.server.close();
 });
 
 
-test('(polka) middleware only w/ mutation', async t => {
-	t.plan(5);
+test('middleware only w/ mutation', async () => {
+	// t.plan(5);
 
 	let app = (
 		polka()
 			.use('/foo', (req, rest, next) => {
-				t.is(req.url, '/123', '~> use("/foo") saw truncated url');
+				assert.is(req.url, '/123', '~> use("/foo") saw truncated url');
 				next();
 			})
 			.use('/foo/:id', (req, res, next) => {
-				t.is(req.url, '/', '~> use("/foo/:id") saw truncated url');
+				assert.is(req.url, '/', '~> use("/foo/:id") saw truncated url');
 				next();
 			})
 			.get('/foo/:id', (req, res) => {
-				t.is(req.url, '/foo/123', '~> get("/foo/:id") saw full url');
+				assert.is(req.url, '/foo/123', '~> get("/foo/:id") saw full url');
 				res.end(req.url);
 			})
 	);
 
-	let uri = listen(app);
+	let uri = $.listen(app);
 
 	let res = await get(uri + '/foo/123');
-	t.is(res.statusCode, 200, '~> received 200 status');
-	t.is(res.data, '/foo/123', '~> received "/foo/123" response');
+	assert.is(res.statusCode, 200, '~> received 200 status');
+	assert.is(res.data, '/foo/123', '~> received "/foo/123" response');
 	app.server.close();
 });
 
 
-test('(polka) middleware w/ wildcard', async t => {
-	t.plan(29);
+test('middleware w/ wildcard', async () => {
+	// t.plan(29);
 	let expect;
 
 	let app = (
@@ -760,127 +759,127 @@ test('(polka) middleware w/ wildcard', async t => {
 			}) // global
 			.use('bar', (req, res) => {
 				// runs 2x
-				t.pass('runs the base middleware for: bar');
-				t.is(req.foo, 'foo', '~> runs after `foo` global middleware');
-				t.false(req.url.includes('bar'), '~> strips "bar" base from `req.url`');
-				t.false(req.path.includes('bar'), '~> strips "bar" base from `req.path`');
-				t.ok(req.originalUrl.includes('bar'), '~> keeps "bar" base within `req.originalUrl`');
+				assert.ok('runs the base middleware for: bar');
+				assert.is(req.foo, 'foo', '~> runs after `foo` global middleware');
+				assert.not(req.url.includes('bar'), '~> strips "bar" base from `req.url`');
+				assert.not(req.path.includes('bar'), '~> strips "bar" base from `req.path`');
+				assert.ok(req.originalUrl.includes('bar'), '~> keeps "bar" base within `req.originalUrl`');
 				res.end('hello from bar');
 			})
 			.get('*', (req, res) => {
 				// runs 3x
-				t.pass('runs the MAIN app handler for GET /*');
-				t.is(req.foo, 'foo', '~> runs after `foo` global middleware');
-				t.is(req.url, expect, '~> receives the full, expected URL');
+				assert.ok('runs the MAIN app handler for GET /*');
+				assert.is(req.foo, 'foo', '~> runs after `foo` global middleware');
+				assert.is(req.url, expect, '~> receives the full, expected URL');
 				res.end('hello from wildcard');
 			})
 	);
 
-	let uri = listen(app);
+	let uri = $.listen(app);
 
-	console.log('GET /');
+	// console.log('GET /');
 	let r1 = await get(uri + (expect = '/'));
-	t.is(r1.statusCode, 200, '~> received 200 status');
-	t.is(r1.data, 'hello from wildcard', '~> received "hello from wildcard" response');
+	assert.is(r1.statusCode, 200, '~> received 200 status');
+	assert.is(r1.data, 'hello from wildcard', '~> received "hello from wildcard" response');
 
-	console.log('GET /hello');
+	// console.log('GET /hello');
 	let r2 = await get(uri + (expect = '/hello'));
-	t.is(r2.statusCode, 200, '~> received 200 status');
-	t.is(r2.data, 'hello from wildcard', '~> received "hello from wildcard" response');
+	assert.is(r2.statusCode, 200, '~> received 200 status');
+	assert.is(r2.data, 'hello from wildcard', '~> received "hello from wildcard" response');
 
-	console.log('GET /a/b/c');
+	// console.log('GET /a/b/c');
 	let r3 = await get(uri + (expect = '/a/b/c'));
-	t.is(r3.statusCode, 200, '~> received 200 status');
-	t.is(r3.data, 'hello from wildcard', '~> received "hello from wildcard" response');
+	assert.is(r3.statusCode, 200, '~> received 200 status');
+	assert.is(r3.data, 'hello from wildcard', '~> received "hello from wildcard" response');
 
-	console.log('GET /bar');
+	// console.log('GET /bar');
 	let r4 = await get(`${uri}/bar`);
-	t.is(r4.statusCode, 200, '~> received 200 status');
-	t.is(r4.data, 'hello from bar', '~> received "hello from bar" response');
+	assert.is(r4.statusCode, 200, '~> received 200 status');
+	assert.is(r4.data, 'hello from bar', '~> received "hello from bar" response');
 
-	console.log('GET /bar/extra');
+	// console.log('GET /bar/extra');
 	let r5 = await get(`${uri}/bar/extra`);
-	t.is(r5.statusCode, 200, '~> received 200 status');
-	t.is(r5.data, 'hello from bar', '~> received "hello from bar" response');
+	assert.is(r5.statusCode, 200, '~> received 200 status');
+	assert.is(r5.data, 'hello from bar', '~> received "hello from bar" response');
 
 	app.server.close();
 });
 
 
 if (hasNamedGroups) {
-	test('(polka) RegExp routes', async t => {
-		t.plan(29);
+	test('RegExp routes', async () => {
+		// t.plan(29);
 
 		let app = (
 			polka()
 				.use(/^\/movies/i, (req, res, next) => {
 					req.foo = 'foo';
-					t.pass('runs the /movies/i middleware group');
-					t.is(req.originalUrl, '/movies/1997/titanic', '~> sees correct `originalUrl` value');
-					t.is(req.path, '/1997/titanic', '~> sees correct `path` value');
+					assert.ok('runs the /movies/i middleware group');
+					assert.is(req.originalUrl, '/movies/1997/titanic', '~> sees correct `originalUrl` value');
+					assert.is(req.path, '/1997/titanic', '~> sees correct `path` value');
 					next();
 				}) // global
 				.use(/^\/books[/](?<title>[^/]+)/i, (req, res) => {
-					t.pass('runs the /books/<title>/i middleware group');
-					t.is(req.originalUrl, '/books/narnia/comments?foo', '~> sees correct `originalUrl` value');
-					t.is(req.path, '/comments', '~> sees correct `path` value – REPLACED PATTERN');
-					t.is(req.url, '/comments?foo', '~> sees correct `url` value – REPLACED PATTERN');
-					t.is(req.params.title, 'narnia', '~> receives correct `params.title` value');
-					t.same(req.query, { foo: '' }, '~> receives correct `req.query` value');
+					assert.ok('runs the /books/<title>/i middleware group');
+					assert.is(req.originalUrl, '/books/narnia/comments?foo', '~> sees correct `originalUrl` value');
+					assert.is(req.path, '/comments', '~> sees correct `path` value – REPLACED PATTERN');
+					assert.is(req.url, '/comments?foo', '~> sees correct `url` value – REPLACED PATTERN');
+					assert.is(req.params.title, 'narnia', '~> receives correct `params.title` value');
+					assert.equal(req.query, { foo: '' }, '~> receives correct `req.query` value');
 					res.end('cya~!');
 				}) // global
 				.use(/^\/songs.*/i, (req, res) => {
-					t.pass('runs the /songs.*/i middleware group');
-					t.is(req.originalUrl, '/songs/foo/bar/baz', '~> sees correct `originalUrl` value');
-					t.is(req.path, '/', '~> sees correct `path` value – REPLACED/MATCHED ALL BCUZ PATTERN');
-					t.is(req.url, '/', '~> sees correct `url` value – REPLACED/MATCHED ALL BCUZ PATTERN');
+					assert.ok('runs the /songs.*/i middleware group');
+					assert.is(req.originalUrl, '/songs/foo/bar/baz', '~> sees correct `originalUrl` value');
+					assert.is(req.path, '/', '~> sees correct `path` value – REPLACED/MATCHED ALL BCUZ PATTERN');
+					assert.is(req.url, '/', '~> sees correct `url` value – REPLACED/MATCHED ALL BCUZ PATTERN');
 					res.end('rekt');
 				}) // global
 				.get(/^\/movies[/](?<year>[0-9]{4})[/](?<title>[^/]+)/i, (req, res) => {
-					t.pass('runs the /movies/<year>/<title> route');
-					t.is(req.foo, 'foo', '~> runs after `foo` global middleware');
-					t.is(req.params.year, '1997', '~> receives correct `params.year` value');
-					t.is(req.params.title, 'titanic', '~> receives correct `params.title` value');
+					assert.ok('runs the /movies/<year>/<title> route');
+					assert.is(req.foo, 'foo', '~> runs after `foo` global middleware');
+					assert.is(req.params.year, '1997', '~> receives correct `params.year` value');
+					assert.is(req.params.title, 'titanic', '~> receives correct `params.title` value');
 					res.end('bye~!');
 				})
 				.get(/.*/, (req , res) => {
-					t.pass('runs the wildcard route');
-					t.not(req.foo, 'foo', '~> did not run after `foo` global middleware');
-					t.is(req.originalUrl, '/hello-world?foo=bar', '~> sees correct `originalUrl` value');
-					t.is(req.path, '/hello-world', '~> sees correct `path` value');
+					assert.ok('runs the wildcard route');
+					assert.is.not(req.foo, 'foo', '~> did not run after `foo` global middleware');
+					assert.is(req.originalUrl, '/hello-world?foo=bar', '~> sees correct `originalUrl` value');
+					assert.is(req.path, '/hello-world', '~> sees correct `path` value');
 					res.end('hello from wildcard');
 				})
 		);
 
-		let uri = listen(app);
+		let uri = $.listen(app);
 
-		console.log('GET /hello-world?foo=bar');
+		// console.log('GET /hello-world?foo=bar');
 		let r1 = await get(uri + '/hello-world?foo=bar');
-		t.is(r1.statusCode, 200, '~> received 200 status');
-		t.is(r1.data, 'hello from wildcard', '~> received "hello from wildcard" response');
+		assert.is(r1.statusCode, 200, '~> received 200 status');
+		assert.is(r1.data, 'hello from wildcard', '~> received "hello from wildcard" response');
 
-		console.log('GET /movies/1997/titanic');
+		// console.log('GET /movies/1997/titanic');
 		let r2 = await get(uri + '/movies/1997/titanic');
-		t.is(r2.statusCode, 200, '~> received 200 status');
-		t.is(r2.data, 'bye~!', '~> received "bye~!" response');
+		assert.is(r2.statusCode, 200, '~> received 200 status');
+		assert.is(r2.data, 'bye~!', '~> received "bye~!" response');
 
-		console.log('GET /books/narnia/comments?foo');
+		// console.log('GET /books/narnia/comments?foo');
 		let r3 = await get(uri + '/books/narnia/comments?foo');
-		t.is(r3.statusCode, 200, '~> received 200 status');
-		t.is(r3.data, 'cya~!', '~> received "cya~!" response');
+		assert.is(r3.statusCode, 200, '~> received 200 status');
+		assert.is(r3.data, 'cya~!', '~> received "cya~!" response');
 
-		console.log('GET /songs/foo/bar/baz');
+		// console.log('GET /songs/foo/bar/baz');
 		let r4 = await get(uri + '/songs/foo/bar/baz');
-		t.is(r4.statusCode, 200, '~> received 200 status');
-		t.is(r4.data, 'rekt', '~> received "rekt" response');
+		assert.is(r4.statusCode, 200, '~> received 200 status');
+		assert.is(r4.data, 'rekt', '~> received "rekt" response');
 
 		app.server.close();
 	});
 }
 
 
-test('(polka) errors – `new Error()`', async t => {
-	t.plan(3);
+test('errors – `new Error()`', async () => {
+	// t.plan(3);
 
 	let app = (
 		polka()
@@ -895,19 +894,19 @@ test('(polka) errors – `new Error()`', async t => {
 	);
 
 	let val = 41;
-	let uri = listen(app);
+	let uri = $.listen(app);
 	await get(uri).catch(err => {
-		t.is(val, 42, 'exits before route handler if middleware error');
-		t.is(err.data, 'boo', '~> received "boo" text');
-		t.is(err.statusCode, 500, '~> received 500 status');
+		assert.is(val, 42, 'exits before route handler if middleware error');
+		assert.is(err.data, 'boo', '~> received "boo" text');
+		assert.is(err.statusCode, 500, '~> received 500 status');
 	});
 
 	app.server.close();
 });
 
 
-test('(polka) errors – `next(msg)`', async t => {
-	t.plan(3);
+test('errors – `next(msg)`', async () => {
+	// t.plan(3);
 
 	let app = (
 		polka()
@@ -921,19 +920,19 @@ test('(polka) errors – `next(msg)`', async t => {
 	);
 
 	let val = 42;
-	let uri = listen(app);
+	let uri = $.listen(app);
 	await get(uri).catch(err => {
-		t.is(val, 42, 'exits without running route handler');
-		t.is(err.data, 'boo~!', '~> received "boo~!" text');
-		t.is(err.statusCode, 500, '~> received 500 status');
+		assert.is(val, 42, 'exits without running route handler');
+		assert.is(err.data, 'boo~!', '~> received "boo~!" text');
+		assert.is(err.statusCode, 500, '~> received 500 status');
 	});
 
 	app.server.close();
 });
 
 
-test('(polka) errors – `throw Error`', async t => {
-	t.plan(3);
+test('errors – `throw Error`', async () => {
+	// t.plan(3);
 
 	let app = (
 		polka()
@@ -949,19 +948,19 @@ test('(polka) errors – `throw Error`', async t => {
 	);
 
 	let val = 42;
-	let uri = listen(app);
+	let uri = $.listen(app);
 	await get(uri).catch(err => {
-		t.is(val, 42, 'exits without running route handler');
-		t.is(err.data, 'hello', '~> received "hello" text');
-		t.is(err.statusCode, 418, '~> received 418 status (custom)');
+		assert.is(val, 42, 'exits without running route handler');
+		assert.is(err.data, 'hello', '~> received "hello" text');
+		assert.is(err.statusCode, 418, '~> received 418 status (custom)');
 	});
 
 	app.server.close();
 });
 
 
-test('(polka) errors – `throw msg`', async t => {
-	t.plan(3);
+test('errors – `throw msg`', async () => {
+	// t.plan(3);
 
 	let app = (
 		polka()
@@ -975,19 +974,19 @@ test('(polka) errors – `throw msg`', async t => {
 	);
 
 	let val = 42;
-	let uri = listen(app);
+	let uri = $.listen(app);
 	await get(uri).catch(err => {
-		t.is(val, 42, 'exits without running route handler');
-		t.is(err.data, 'surprise', '~> received "surprise" text');
-		t.is(err.statusCode, 500, '~> received 500 status');
+		assert.is(val, 42, 'exits without running route handler');
+		assert.is(err.data, 'surprise', '~> received "surprise" text');
+		assert.is(err.statusCode, 500, '~> received 500 status');
 	});
 
 	app.server.close();
 });
 
 
-test('(polka) errors – manual `res.end` exit', async t => {
-	t.plan(3)
+test('errors – manual `res.end` exit', async () => {
+	// t.plan(3)
 
 	// early res.end()
 	let app = (
@@ -1003,19 +1002,19 @@ test('(polka) errors – manual `res.end` exit', async t => {
 	);
 
 	let val = 42;
-	let uri = listen(app);
+	let uri = $.listen(app);
 	await get(uri).catch(err => {
-		t.is(val, 42, 'exits without running route handler');
-		t.is(err.data, 'oh dear', '~> received "oh dear" (custom) text');
-		t.is(err.statusCode, 501, '~> received 501 (custom) status');
+		assert.is(val, 42, 'exits without running route handler');
+		assert.is(err.data, 'oh dear', '~> received "oh dear" (custom) text');
+		assert.is(err.statusCode, 501, '~> received 501 (custom) status');
 	});
 
 	app.server.close();
 });
 
 
-test('(polka) sub-application', async t => {
-	t.plan(24);
+test('sub-application', async () => {
+	// t.plan(24);
 
 	function foo(req, res, next) {
 		req.foo = 'hello';
@@ -1023,7 +1022,7 @@ test('(polka) sub-application', async t => {
 	}
 
 	function bar(req, res, next) {
-		t.pass('runs the sub-application middleware'); // runs 2x
+		assert.ok('runs the sub-application middleware'); // runs 2x
 		req.bar = 'world';
 		next();
 	}
@@ -1032,21 +1031,21 @@ test('(polka) sub-application', async t => {
 		polka()
 			.use(bar)
 			.get('/', (req, res) => {
-				t.pass('runs the sub-application / route');
-				t.is(req.url, '/', '~> trims basepath from `req.url` value');
-				t.is(req.originalUrl, '/sub', '~> preserves original `req.url` value');
-				t.is(req.foo, 'hello', '~> receives mutatations from main-app middleware');
-				t.is(req.bar, 'world', '~> receives mutatations from own middleware');
+				assert.ok('runs the sub-application / route');
+				assert.is(req.url, '/', '~> trims basepath from `req.url` value');
+				assert.is(req.originalUrl, '/sub', '~> preserves original `req.url` value');
+				assert.is(req.foo, 'hello', '~> receives mutatations from main-app middleware');
+				assert.is(req.bar, 'world', '~> receives mutatations from own middleware');
 				res.end('hello from sub@index');
 			})
 			.get('/:bar', (req, res) => {
-				t.pass('runs the sub-application /:id route');
-				t.is(req.params.bar, 'hi', '~> parses the sub-application params');
-				t.is(req.url, '/hi?a=0', '~> trims basepath from `req.url` value');
-				t.same(req.query, {a:'0'}, '~> parses the sub-application `res.query` value');
-				t.is(req.originalUrl, '/sub/hi?a=0', '~> preserves original `req.url` value');
-				t.is(req.foo, 'hello', '~> receives mutatations from main-app middleware');
-				t.is(req.bar, 'world', '~> receives mutatations from own middleware');
+				assert.ok('runs the sub-application /:id route');
+				assert.is(req.params.bar, 'hi', '~> parses the sub-application params');
+				assert.is(req.url, '/hi?a=0', '~> trims basepath from `req.url` value');
+				assert.equal(req.query, {a:'0'}, '~> parses the sub-application `res.query` value');
+				assert.is(req.originalUrl, '/sub/hi?a=0', '~> preserves original `req.url` value');
+				assert.is(req.foo, 'hello', '~> receives mutatations from main-app middleware');
+				assert.is(req.bar, 'world', '~> receives mutatations from own middleware');
 				res.end('hello from sub@show');
 			})
 	);
@@ -1056,47 +1055,47 @@ test('(polka) sub-application', async t => {
 			.use(foo)
 			.use('sub', sub)
 			.get('/', (req, res) => {
-				t.pass('run the main-application route');
-				t.is(req.foo, 'hello', '~> receives mutatations from middleware');
-				t.is(req.bar, undefined, '~> does NOT run the sub-application middleware');
-				t.is(req.originalUrl, '/', '~> always sets `req.originalUrl` key');
+				assert.ok('run the main-application route');
+				assert.is(req.foo, 'hello', '~> receives mutatations from middleware');
+				assert.is(req.bar, undefined, '~> does NOT run the sub-application middleware');
+				assert.is(req.originalUrl, '/', '~> always sets `req.originalUrl` key');
 				res.end('hello from main');
 			})
 	);
 
-	let uri = listen(app);
+	let uri = $.listen(app);
 
 	// check sub-app index route
-	console.log('GET /sub');
+	// console.log('GET /sub');
 	let r1 = await get(`${uri}/sub`);
-	t.is(r1.statusCode, 200, '~> received 200 status');
-	t.is(r1.data, 'hello from sub@index', '~> received "hello from sub@index" response');
+	assert.is(r1.statusCode, 200, '~> received 200 status');
+	assert.is(r1.data, 'hello from sub@index', '~> received "hello from sub@index" response');
 
 	// check main-app now
-	console.log('GET /');
+	// console.log('GET /');
 	let r2 = await get(uri);
-	t.is(r2.statusCode, 200, '~> received 200 status');
-	t.is(r2.data, 'hello from main', '~> received "hello from main" response');
+	assert.is(r2.statusCode, 200, '~> received 200 status');
+	assert.is(r2.data, 'hello from main', '~> received "hello from main" response');
 
 	// check sub-app pattern route
-	console.log('GET /sub/hi?a=0');
+	// console.log('GET /sub/hi?a=0');
 	let r3 = await get(`${uri}/sub/hi?a=0`)
-	t.is(r3.statusCode, 200, '~> received 200 status');
-	t.is(r3.data, 'hello from sub@show', '~> received "hello from sub@show" response');
+	assert.is(r3.statusCode, 200, '~> received 200 status');
+	assert.is(r3.data, 'hello from sub@show', '~> received "hello from sub@show" response');
 
 	app.server.close();
 });
 
-test('(polka) sub-application w/ query params', async t => {
-	t.plan(12);
+test('sub-application w/ query params', async () => {
+	// t.plan(12);
 
 	let sub = (
 		polka()
 			.get('/', (req, res) => {
-				t.pass('runs the sub-application / route');
-				t.is(req.url, '/?foo=bar', '~> trims basepath from `req.url` value');
-				t.is(req.originalUrl, '/sub?foo=bar', '~> preserves original `req.url` value');
-				t.same(req.query, { foo: 'bar' }, '~> preserves original `req.query` value');
+				assert.ok('runs the sub-application / route');
+				assert.is(req.url, '/?foo=bar', '~> trims basepath from `req.url` value');
+				assert.is(req.originalUrl, '/sub?foo=bar', '~> preserves original `req.url` value');
+				assert.equal(req.query, { foo: 'bar' }, '~> preserves original `req.query` value');
 				res.end('hello from sub@index');
 			})
 	);
@@ -1105,37 +1104,37 @@ test('(polka) sub-application w/ query params', async t => {
 		polka()
 			.use('/sub', sub)
 			.get('/', (req, res) => {
-				t.pass('run the main-application route');
-				t.is(req.url, '/?foo=123', '~> always sets `req.originalUrl` key');
-				t.is(req.originalUrl, '/?foo=123', '~> always sets `req.originalUrl` key');
-				t.same(req.query, { foo: '123' }, '~> sets the `req.query` value');
+				assert.ok('run the main-application route');
+				assert.is(req.url, '/?foo=123', '~> always sets `req.originalUrl` key');
+				assert.is(req.originalUrl, '/?foo=123', '~> always sets `req.originalUrl` key');
+				assert.equal(req.query, { foo: '123' }, '~> sets the `req.query` value');
 				res.end('hello from main');
 			})
 	);
 
-	let uri = listen(app);
+	let uri = $.listen(app);
 
 	// check sub-app index route
-	console.log('GET /sub?foo=bar');
+	// console.log('GET /sub?foo=bar');
 	let r1 = await get(`${uri}/sub?foo=bar`); // +4
-	t.is(r1.statusCode, 200, '~> received 200 status');
-	t.is(r1.data, 'hello from sub@index', '~> received "hello from sub@index" response');
+	assert.is(r1.statusCode, 200, '~> received 200 status');
+	assert.is(r1.data, 'hello from sub@index', '~> received "hello from sub@index" response');
 
 	// check main-app now
-	console.log('GET /?foo=123');
+	// console.log('GET /?foo=123');
 	let r2 = await get(uri + '?foo=123'); // +4
-	t.is(r2.statusCode, 200, '~> received 200 status');
-	t.is(r2.data, 'hello from main', '~> received "hello from main" response');
+	assert.is(r2.statusCode, 200, '~> received 200 status');
+	assert.is(r2.data, 'hello from main', '~> received "hello from main" response');
 
 	app.server.close();
 });
 
 
-test('(polka) sub-application & middleware', async t => {
-	t.plan(19);
+test('sub-application & middleware', async () => {
+	// t.plan(19);
 
 	function verify(req, res, next) {
-		t.is(req.main, true, '~> VERIFY middleware ran after MAIN');
+		assert.is(req.main, true, '~> VERIFY middleware ran after MAIN');
 		req.verify = true;
 		next();
 	}
@@ -1144,35 +1143,35 @@ test('(polka) sub-application & middleware', async t => {
 	const api = polka();
 
 	api.use((req, res, next) => {
-		t.is(req.main, true, '~> API middleware ran after MAIN');
-		t.is(req.verify, true, '~> API middleware ran after VERIFY');
+		assert.is(req.main, true, '~> API middleware ran after MAIN');
+		assert.is(req.verify, true, '~> API middleware ran after VERIFY');
 		req.api = true;
 		next();
 	});
 
 	api.use('/users', (req, res, next) => {
-		t.is(req.main, true, '~> API/users middleware ran after MAIN');
-		t.is(req.verify, true, '~> API middleware ran after VERIFY');
-		t.is(req.api, true, '~> API/users middleware ran after API');
+		assert.is(req.main, true, '~> API/users middleware ran after MAIN');
+		assert.is(req.verify, true, '~> API middleware ran after VERIFY');
+		assert.is(req.api, true, '~> API/users middleware ran after API');
 		req.users = true;
 		next();
 	});
 
 	api.get('/users/:id', (req, res, next) => {
-		t.is(req.main, true, '~> GET API/users/:id #1 ran after MAIN');
-		t.is(req.verify, true, '~> API middleware ran after VERIFY');
-		t.is(req.api, true, '~> GET API/users/:id #1 ran after API');
-		t.is(req.users, true, '~> GET API/users/:id #1 ran after API/users');
-		t.is(req.params.id, 'BOB', '~> GET /API/users/:id #1 received the `params.id` value');
+		assert.is(req.main, true, '~> GET API/users/:id #1 ran after MAIN');
+		assert.is(req.verify, true, '~> API middleware ran after VERIFY');
+		assert.is(req.api, true, '~> GET API/users/:id #1 ran after API');
+		assert.is(req.users, true, '~> GET API/users/:id #1 ran after API/users');
+		assert.is(req.params.id, 'BOB', '~> GET /API/users/:id #1 received the `params.id` value');
 		req.userid = true;
 		next();
 	}, (req, res) => {
-		t.is(req.main, true, '~> GET API/users/:id #2 ran after MAIN');
-		t.is(req.verify, true, '~> API middleware ran after VERIFY');
-		t.is(req.api, true, '~> GET API/users/:id #2 ran after API');
-		t.is(req.users, true, '~> GET API/users/:id #2 ran after API/users');
-		t.is(req.userid, true, '~> GET API/users/:id #2 ran after GET API/users/:id #1');
-		t.is(req.params.id, 'BOB', '~> GET /API/users/:id #2 received the `params.id` value');
+		assert.is(req.main, true, '~> GET API/users/:id #2 ran after MAIN');
+		assert.is(req.verify, true, '~> API middleware ran after VERIFY');
+		assert.is(req.api, true, '~> GET API/users/:id #2 ran after API');
+		assert.is(req.users, true, '~> GET API/users/:id #2 ran after API/users');
+		assert.is(req.userid, true, '~> GET API/users/:id #2 ran after GET API/users/:id #1');
+		assert.is(req.params.id, 'BOB', '~> GET /API/users/:id #2 received the `params.id` value');
 		res.end(`Hello, ${req.params.id}`);
 	});
 
@@ -1186,138 +1185,137 @@ test('(polka) sub-application & middleware', async t => {
 			.use('/api', verify, api)
 	);
 
-	let uri = listen(main);
+	let uri = $.listen(main);
 	let r = await get(uri + '/api/users/BOB');
-	t.is(r.statusCode, 200, '~> received 200 status');
-	t.is(r.data, 'Hello, BOB', '~> received "Hello, BOB" response');
+	assert.is(r.statusCode, 200, '~> received 200 status');
+	assert.is(r.data, 'Hello, BOB', '~> received "Hello, BOB" response');
 
 	main.server.close();
 });
 
 
-test('(polka) options.server', t => {
+test('options.server', () => {
 	let server = http.createServer();
 	let app = polka({ server });
-	t.same(app.server, server, '~> store custom server internally as is');
+	assert.equal(app.server, server, '~> store custom server internally as is');
 
 	app.listen();
-	t.isFunction(server._events.request, '~> attaches `Polka.handler` to server');
+	$.isFunction(server._events.request, '~> attaches `Polka.handler` to server');
 
 	app.server.close();
-	t.end();
 });
 
 
-test('(polka) options.onError', async t => {
-	t.plan(3);
+test('options.onError', async () => {
+	// t.plan(3);
 
 	let app = polka().use((req, res, next) => next('Oops!'));
-	t.isFunction(app.onError, '~> attaches default `app.onError` handler');
+	$.isFunction(app.onError, '~> attaches default `app.onError` handler');
 
-	let uri = listen(app);
+	let uri = $.listen(app);
 	await get(uri).catch(err => {
-		t.is(err.statusCode, 500, '~> response gets 500 code (default)');
-		t.is(err.data, 'Oops!', '~> response body is "Oops!" string');
+		assert.is(err.statusCode, 500, '~> response gets 500 code (default)');
+		assert.is(err.data, 'Oops!', '~> response body is "Oops!" string');
 	});
 
 	app.server.close();
 });
 
 
-test('(polka) options.onError (err.code)', async t => {
-	t.plan(3);
+test('options.onError (err.code)', async () => {
+	// t.plan(3);
 
 	let foo = new Error('Oops!');
 	foo.code = 418;
 
 	let app = polka().use((req, res, next) => next(foo));
-	t.isFunction(app.onError, '~> attaches default `app.onError` handler');
+	$.isFunction(app.onError, '~> attaches default `app.onError` handler');
 
-	let uri = listen(app);
+	let uri = $.listen(app);
 	await get(uri).catch(err => {
-		t.is(err.statusCode, 418, '~> response has 418 code (via "err.code" key)');
-		t.is(err.data, 'Oops!', '~> response body is "Oops!" string');
+		assert.is(err.statusCode, 418, '~> response has 418 code (via "err.code" key)');
+		assert.is(err.data, 'Oops!', '~> response body is "Oops!" string');
 	});
 
 	app.server.close();
 });
 
 
-test('(polka) options.onError (err.status)', async t => {
-	t.plan(3);
+test('options.onError (err.status)', async () => {
+	// t.plan(3);
 
 	let foo = new Error('Oops!');
 	foo.status = 418;
 
 	let app = polka().use((req, res, next) => next(foo));
-	t.isFunction(app.onError, '~> attaches default `app.onError` handler');
+	$.isFunction(app.onError, '~> attaches default `app.onError` handler');
 
-	let uri = listen(app);
+	let uri = $.listen(app);
 	await get(uri).catch(err => {
-		t.is(err.statusCode, 418, '~> response has 418 code (via "err.status" key)');
-		t.is(err.data, 'Oops!', '~> response body is "Oops!" string');
+		assert.is(err.statusCode, 418, '~> response has 418 code (via "err.status" key)');
+		assert.is(err.data, 'Oops!', '~> response body is "Oops!" string');
 	});
 
 	app.server.close();
 });
 
 
-test('(polka) options.onError – custom', async t => {
-	t.plan(7);
+test('options.onError – custom', async () => {
+	// t.plan(7);
 
 	let foo = new Error('boo~!');
 	foo.code = 418;
 
 	function onError(err, req, res, next) {
-		t.same(err, foo, '~> receives the `err` object directly as 1st param');
-		t.ok(req.url, '~> receives the `req` object as 2nd param');
-		t.isFunction(res.end, '~> receives the `res` object as 3rd param');
-		t.isFunction(next, '~> receives the `next` function 4th param'); // in case want to skip?
+		assert.equal(err, foo, '~> receives the `err` object directly as 1st param');
+		assert.ok(req.url, '~> receives the `req` object as 2nd param');
+		$.isFunction(res.end, '~> receives the `res` object as 3rd param');
+		$.isFunction(next, '~> receives the `next` function 4th param'); // in case want to skip?
 		res.statusCode = err.code;
 		res.end('error: ' + err.message);
 	}
 
 	let app = polka({ onError }).use((req, res, next) => next(foo));
-	t.is(app.onError, onError, 'replaces `app.onError` with the option value');
-	let uri = listen(app);
+	assert.is(app.onError, onError, 'replaces `app.onError` with the option value');
+	let uri = $.listen(app);
 
 	await get(uri).catch(err => {
-		t.is(err.statusCode, 418, '~> response has 418 statusCode');
-		t.is(err.data, 'error: boo~!', '~> response body is formatted string');
+		assert.is(err.statusCode, 418, '~> response has 418 statusCode');
+		assert.is(err.data, 'error: boo~!', '~> response body is formatted string');
 	});
 
 	app.server.close();
 });
 
 
-test('(polka) options.onNoMatch', async t => {
-	t.plan(7);
+test('options.onNoMatch', async () => {
+	// t.plan(7);
 
 	let foo = (req, res, next) => {
-		t.ok(req.url, '~> receives the `req` object as 1st param');
-		t.isFunction(res.end, '~> receives the `res` object as 2nd param');
-		t.isFunction(next, '~> receives the `next` function 3rd param'); // in case want to skip?
+		assert.ok(req.url, '~> receives the `req` object as 1st param');
+		$.isFunction(res.end, '~> receives the `res` object as 2nd param');
+		$.isFunction(next, '~> receives the `next` function 3rd param'); // in case want to skip?
 		res.statusCode = 405;
 		res.end('prefer: Method Not Found');
 	};
 
 	let app = polka({ onNoMatch:foo }).get('/', () => {});
 
-	t.is(app.onNoMatch, foo, 'replaces `app.onNoMatch` with the option value');
-	t.not(app.onError, foo, 'does not affect the `app.onError` handler');
+	assert.is(app.onNoMatch, foo, 'replaces `app.onNoMatch` with the option value');
+	assert.is.not(app.onError, foo, 'does not affect the `app.onError` handler');
 
-	let uri = listen(app);
+	let uri = $.listen(app);
 	await post(uri).catch(err => {
-		t.is(err.statusCode, 405, '~> response gets the error code');
-		t.is(err.data, 'prefer: Method Not Found', '~> response gets the formatted error message');
+		assert.is(err.statusCode, 405, '~> response gets the error code');
+		assert.is(err.data, 'prefer: Method Not Found', '~> response gets the formatted error message');
 	});
 
 	app.server.close();
 });
 
 
-test('(polka) HEAD', async t => {
-	t.plan(21);
+test('HEAD', async () => {
+	// t.plan(21);
 
 	function foo(req, res, next) {
 		req.foo = req.foo || 0;
@@ -1334,74 +1332,77 @@ test('(polka) HEAD', async t => {
 	let app = (
 		polka()
 			.head('/hello', foo, bar, (req, res) => {
-				t.pass('~> inside "HEAD /hello" handler');
-				t.is(req.foo, 250, '~> foo() ran once');
-				t.is(req.bar, 'bar', '~> bar() ran once');
+				assert.ok('~> inside "HEAD /hello" handler');
+				assert.is(req.foo, 250, '~> foo() ran once');
+				assert.is(req.bar, 'bar', '~> bar() ran once');
 				res.end('world');
 			})
 			.head('/posts/*', (req, res, next) => {
-				t.pass('~> inside "HEAD /posts/*" handler');
+				assert.ok('~> inside "HEAD /posts/*" handler');
 				req.head = true;
 				next();
 			})
 			.get('/posts/:title', foo, bar, (req, res) => {
-				t.pass('~> inside GET "/posts/:title" handler');
+				assert.ok('~> inside GET "/posts/:title" handler');
 				if (req.method === 'HEAD') {
-					t.is(req.head, true, '~> ran after "HEAD posts/*" handler');
+					assert.is(req.head, true, '~> ran after "HEAD posts/*" handler');
 				}
-				t.is(req.foo, 250, '~> foo() ran once');
-				t.is(req.bar, 'bar', '~> bar() ran once');
+				assert.is(req.foo, 250, '~> foo() ran once');
+				assert.is(req.bar, 'bar', '~> bar() ran once');
 				res.end(req.params.title);
 			})
 	);
 
-	t.is(app.routes.length, 3, 'added 3 routes in total');
-	t.is(app.find('HEAD', '/hello').handlers.length, 3, '~> has 3 handlers for "HEAD /hello" route');
-	t.is(app.find('GET', '/posts/hello').handlers.length, 3, '~> has 3 handlers for "GET /posts/hello" route');
-	t.is(app.find('HEAD', '/posts/hello').handlers.length, 4, '~> has 4 handlers for "HEAD /posts/hello" route');
+	assert.is(app.routes.length, 3, 'added 3 routes in total');
+	assert.is(app.find('HEAD', '/hello').handlers.length, 3, '~> has 3 handlers for "HEAD /hello" route');
+	assert.is(app.find('GET', '/posts/hello').handlers.length, 3, '~> has 3 handlers for "GET /posts/hello" route');
+	assert.is(app.find('HEAD', '/posts/hello').handlers.length, 4, '~> has 4 handlers for "HEAD /posts/hello" route');
 
-	let uri = listen(app);
+	let uri = $.listen(app);
 
-	console.log('HEAD /hello');
+	// console.log('HEAD /hello');
 	let r = await send('HEAD', uri + '/hello');
-	t.is(r.statusCode, 200, '~> received 200 status');
-	t.is(r.data, '', '~> received empty response');
+	assert.is(r.statusCode, 200, '~> received 200 status');
+	assert.is(r.data, '', '~> received empty response');
 
-	console.log('HEAD /posts/narnia');
+	// console.log('HEAD /posts/narnia');
 	r = await send('HEAD', uri + '/posts/narnia');
-	t.is(r.statusCode, 200, '~> received 200 status');
-	t.is(r.data, '', '~> received empty response');
+	assert.is(r.statusCode, 200, '~> received 200 status');
+	assert.is(r.data, '', '~> received empty response');
 
-	console.log('GET /posts/narnia');
+	// console.log('GET /posts/narnia');
 	r = await get(uri + '/posts/narnia');
-	t.is(r.statusCode, 200, '~> received 200 status');
-	t.is(r.data, 'narnia', '~> received "narnia" response');
+	assert.is(r.statusCode, 200, '~> received 200 status');
+	assert.is(r.data, 'narnia', '~> received "narnia" response');
 
 	app.server.close();
 });
 
 
-test('(polka) decode url', async t => {
-	t.plan(8);
+test('decode url', async () => {
+	// t.plan(8);
 
 	let sub = (
 		polka()
 			.get('/:foo', (req, res) => {
-				t.pass('~> inside "GET /sub/:foo" handler')
-				t.true(req._decoded, '~> marked as decoded');
-				t.is(req.path, '/føøß∂r', '~> decoded "path" value');
-				t.is(req.url, '/føøß∂r?phone=+8675309', '~> decoded "url" value fully');
-				t.is(req.params.foo, 'føøß∂r', '~> decoded "params.foo" segment');
-				t.is(req.query.phone, '+8675309', '~~> does NOT decode "req.query" keys twice');
+				assert.ok('~> inside "GET /sub/:foo" handler')
+				assert.ok(req._decoded, '~> marked as decoded');
+				assert.is(req.path, '/føøß∂r', '~> decoded "path" value');
+				assert.is(req.url, '/føøß∂r?phone=+8675309', '~> decoded "url" value fully');
+				assert.is(req.params.foo, 'føøß∂r', '~> decoded "params.foo" segment');
+				assert.is(req.query.phone, '+8675309', '~~> does NOT decode "req.query" keys twice');
 				res.end('done');
 			})
 	);
 
 	let app = polka().use('/sub', sub);
-	let uri = listen(app);
+	let uri = $.listen(app);
 
 	let r = await get(uri + '/sub/f%C3%B8%C3%B8%C3%9F%E2%88%82r?phone=%2b8675309')
-	t.is(r.statusCode, 200, '~> received 200 status');
-	t.is(r.data, 'done', '~> received response');
+	assert.is(r.statusCode, 200, '~> received 200 status');
+	assert.is(r.data, 'done', '~> received response');
 	app.server.close();
 });
+
+
+test.run();

--- a/packages/polka/test/util/index.js
+++ b/packages/polka/test/util/index.js
@@ -1,21 +1,20 @@
-import tape from 'tape';
+import * as assert from 'uvu/assert';
 
-Object.assign(tape.Test.prototype, {
-	isEmpty(val, msg) {
-		this.ok(!Object.keys(val).length, msg);
-	},
-	isArray(val, msg) {
-		this.ok(Array.isArray(val), msg);
-	},
-	isObject(val, msg) {
-		this.is(Object.prototype.toString.call(val), '[object Object]', msg);
-	},
-	isFunction(val, msg) {
-		this.is(typeof val, 'function', msg);
-	}
-});
+export function isEmpty(val, msg) {
+	assert.ok(!Object.keys(val).length, msg);
+}
 
-export const test = tape;
+export function isArray(val, msg) {
+	assert.ok(Array.isArray(val), msg);
+}
+
+export function isObject(val, msg) {
+	assert.is(Object.prototype.toString.call(val), '[object Object]', msg);
+}
+
+export function isFunction(val, msg) {
+	assert.type(val, 'function', msg);
+}
 
 export function listen(app, host) {
 	app.listen(); // boots

--- a/packages/redirect/test/index.js
+++ b/packages/redirect/test/index.js
@@ -1,17 +1,18 @@
-import test from 'tape';
+import { test } from 'uvu';
+import * as assert from 'uvu/assert';
 import fn from '../index';
 
-test.Test.prototype.isRedirect = function (arr, code=302) {
+function isRedirect(arr, code=302) {
 	let [starting, next, result] = arr;
 	let res = Response(starting);
 	fn(res, code, next);
 
-	console.log(`"${starting}" + "${next}" = "${result}" (${code})`);
-	this.is(res.statusCode, code, `~> sets statusCode`);
-	this.is(res.body, '', '~> sets empty "res.body" content');
-	this.is(res.headers['Content-Length'], 0, '~> sets "Content-Length" header');
-	this.is(res.headers['Location'], result, `~> sets "Location" header`);
-};
+	// console.log(`"${starting}" + "${next}" = "${result}" (${code})`);
+	assert.is(res.statusCode, code, `~> sets statusCode`);
+	assert.is(res.body, '', '~> sets empty "res.body" content');
+	assert.is(res.headers['Content-Length'], 0, '~> sets "Content-Length" header');
+	assert.is(res.headers['Location'], result, `~> sets "Location" header`);
+}
 
 function Response(originalUrl, referrer='') {
 	let res = {
@@ -38,64 +39,59 @@ function Response(originalUrl, referrer='') {
 	return res;
 }
 
-test('(redirect) exports', t => {
-	t.is(typeof fn, 'function', 'exports a function');
-	t.end();
+test('exports', () => {
+	assert.type(fn, 'function');
 });
 
-test('(redirect) defaults', t => {
+test('defaults', () => {
 	let res = Response('/foo/bar/baz');
 	fn(res);
-	t.is(res.statusCode, 302, '~> uses 302 statusCode (default)');
-	t.is(res.headers['Location'], '', '~> sets "Location" as empty (default)');
-	t.end();
+	assert.is(res.statusCode, 302, '~> uses 302 statusCode (default)');
+	assert.is(res.headers['Location'], '', '~> sets "Location" as empty (default)');
 });
 
-test('(redirect) location only', t => {
+test('location only', () => {
 	let res = Response('/foo/bar/baz');
+	// @ts-ignore -- TODO: types
 	fn(res, '/users/123');
-	t.is(res.statusCode, 302, '~> uses 302 statusCode (default)');
-	t.is(res.headers['Location'], '/users/123', '~> sets "Location" header correctly');
-	t.end();
+	assert.is(res.statusCode, 302, '~> uses 302 statusCode (default)');
+	assert.is(res.headers['Location'], '/users/123', '~> sets "Location" header correctly');
 });
 
-test('(redirect) statusCode and location', t => {
+test('statusCode and location', () => {
 	let res = Response('/foo/bar/baz');
 	fn(res, 301, '/users/123');
-	t.is(res.statusCode, 301, '~> uses 301 statusCode (default)');
-	t.is(res.headers['Location'], '/users/123', '~> sets "Location" header correctly');
-	t.end();
+	assert.is(res.statusCode, 301, '~> uses 301 statusCode (default)');
+	assert.is(res.headers['Location'], '/users/123', '~> sets "Location" header correctly');
 });
 
-test('(redirect) "back" ', t => {
+test('"back" ', () => {
 	let res = Response('/foo/bar/baz');
 
+	// @ts-ignore -- TODO: types
 	fn(res, 'back');
-	t.is(res.statusCode, 302, '~> uses 302 statusCode (default)');
-	t.is(res.headers['Location'], '/', '~> uses "/" Location (default)');
+	assert.is(res.statusCode, 302, '~> uses 302 statusCode (default)');
+	assert.is(res.headers['Location'], '/', '~> uses "/" Location (default)');
 
 	fn(res, 301, 'back');
-	t.is(res.statusCode, 301, '~> uses 301 statusCode (custom)');
-	t.is(res.headers['Location'], '/', '~> uses "/" Location (default)');
-
-	t.end();
+	assert.is(res.statusCode, 301, '~> uses 301 statusCode (custom)');
+	assert.is(res.headers['Location'], '/', '~> uses "/" Location (default)');
 });
 
-test('(redirect) "back" w/ Referrer', t => {
+test('"back" w/ Referrer', () => {
 	let res = Response('/foo/bar/baz', '/users/123');
 
+	// @ts-ignore -- TODO: types
 	fn(res, 'back');
-	t.is(res.statusCode, 302, '~> uses 302 statusCode (default)');
-	t.is(res.headers['Location'], '/users/123', '~> uses "/users/123" Location ("Referrer")');
+	assert.is(res.statusCode, 302, '~> uses 302 statusCode (default)');
+	assert.is(res.headers['Location'], '/users/123', '~> uses "/users/123" Location ("Referrer")');
 
 	fn(res, 301, 'back');
-	t.is(res.statusCode, 301, '~> uses 301 statusCode (custom)');
-	t.is(res.headers['Location'], '/users/123', '~> uses "/users/123" Location ("Referrer")');
-
-	t.end();
+	assert.is(res.statusCode, 301, '~> uses 301 statusCode (custom)');
+	assert.is(res.headers['Location'], '/users/123', '~> uses "/users/123" Location ("Referrer")');
 });
 
-test('(redirect) values – relatives', t => {
+test('values – relatives', () => {
 	[
 		['/foo/bar', '/', '/'],
 		['/foo/bar', './', '/foo/'],
@@ -105,13 +101,11 @@ test('(redirect) values – relatives', t => {
 		['/foo/bar/', '../', '/foo/'],
 		['/foo/bar', '../', '/'],
 	].forEach(arr => {
-		t.isRedirect(arr, 302);
+		isRedirect(arr, 302);
 	});
-
-	t.end();
 });
 
-test('(redirect) redirect values', t => {
+test('redirect values', () => {
 	[
 		['/foo/bar', '/', '/'],
 		['/foo/bar', './', '/foo/'],
@@ -125,8 +119,8 @@ test('(redirect) redirect values', t => {
 		['/foo/bar/', '../', '/foo/'],
 		['/foo/bar', '../', '/'],
 	].forEach(arr => {
-		t.isRedirect(arr, 302);
+		isRedirect(arr, 302);
 	});
-
-	t.end();
 });
+
+test.run();

--- a/packages/send/test/index.js
+++ b/packages/send/test/index.js
@@ -1,6 +1,7 @@
 import fs from 'fs';
-import test from 'tape';
+import { suite } from 'uvu';
 import { join } from 'path';
+import * as assert from 'uvu/assert';
 import { Response, toStatusText } from './util';
 import send from '../index';
 
@@ -8,134 +9,165 @@ const TYPE = 'Content-Type';
 const LENGTH = 'Content-Length';
 const INPUT = require.resolve('../');
 
-test('(send) exports', t => {
-	t.is(typeof send, 'function', 'exports a function');
-	t.end();
+const basics = suite('basics');
+
+basics('should export a function', () => {
+	assert.type(send, 'function');
 });
 
-test('(send) basic', t => {
+basics('usage', () => {
 	let res = new Response();
 	let str = toStatusText(200);
 	send(res);
-	t.is(res.statusCode, 200, 'default statusCode: 200');
-	t.is(res.getHeaderNames().length, 2, 'custom headers added: 2');
-	t.is(res.getHeader(TYPE), 'text/plain', 'custom header[type]: text/plain');
-	t.is(res.getHeader(LENGTH), 2, 'custom header[length]: 2');
-	t.is(res.body, str, `fallback body: ${str}`);
-	t.end();
+	assert.is(res.statusCode, 200, 'default statusCode: 200');
+	assert.is(res.getHeaderNames().length, 2, 'custom headers added: 2');
+	assert.is(res.getHeader(TYPE), 'text/plain', 'custom header[type]: text/plain');
+	assert.is(res.getHeader(LENGTH), 2, 'custom header[length]: 2');
+	assert.is(res.body, str, `fallback body: ${str}`);
 });
 
-test('(send) statusCode', t => {
+basics.run();
+
+// ---
+
+const status = suite('statusCode');
+
+status('should set `res.statusCode` value', () => {
 	let res = new Response();
 	let str = toStatusText(404);
 	send(res, 404);
-	t.is(res.statusCode, 404, 'set statusCode: 404');
-	t.is(res.getHeaderNames().length, 2, 'custom headers added: 2');
-	t.is(res.getHeader(TYPE), 'text/plain', 'custom header[type]: text/plain');
-	t.is(res.getHeader(LENGTH), str.length, `custom header[length]: ${str.length}`);
-	t.is(res.body, str, `fallback body: ${str}`);
-	t.end();
+	assert.is(res.statusCode, 404, 'set statusCode: 404');
+	assert.is(res.getHeaderNames().length, 2, 'custom headers added: 2');
+	assert.is(res.getHeader(TYPE), 'text/plain', 'custom header[type]: text/plain');
+	assert.is(res.getHeader(LENGTH), str.length, `custom header[length]: ${str.length}`);
+	assert.is(res.body, str, `fallback body: ${str}`);
 });
 
-test('(send) statusCode – unknown', t => {
+status('should accept any status code value', () => {
 	let res = new Response();
 	let str = '123';
-	send(res, 123);
-	t.is(res.statusCode, 123, 'set statusCode: 123');
-	t.is(res.getHeaderNames().length, 2, 'custom headers added: 2');
-	t.is(res.getHeader(TYPE), 'text/plain', 'custom header[type]: text/plain');
-	t.is(res.getHeader(LENGTH), str.length, `custom header[length]: ${str.length}`);
-	t.is(res.body, str, `fallback body: ${str}`);
-	t.end();
+	send(res, 123); // unknown, but your fault
+	assert.is(res.statusCode, 123, 'set statusCode: 123');
+	assert.is(res.getHeaderNames().length, 2, 'custom headers added: 2');
+	assert.is(res.getHeader(TYPE), 'text/plain', 'custom header[type]: text/plain');
+	assert.is(res.getHeader(LENGTH), str.length, `custom header[length]: ${str.length}`);
+	assert.is(res.body, str, `fallback body: ${str}`);
 });
 
-test('(send) statusCode – 204', t => {
+status('should send empty response content when is `204` code', () => {
 	let res = new Response();
 	send(res, 204);
-	t.is(res.statusCode, 204, 'set statusCode: 204');
-	t.is(res.getHeaderNames().length, 0, 'custom headers added: 0');
-	t.false(res.hasHeader(TYPE), '~> removes header[type]');
-	t.false(res.hasHeader(LENGTH), '~> removes header[length]');
-	t.is(res.body, '', 'empty body');
-	t.end();
+	assert.is(res.statusCode, 204, 'set statusCode: 204');
+	assert.is(res.getHeaderNames().length, 0, 'custom headers added: 0');
+	assert.not(res.hasHeader(TYPE), '~> removes header[type]');
+	assert.not(res.hasHeader(LENGTH), '~> removes header[length]');
+	assert.is(res.body, '', 'empty body');
 });
 
-test('(send) statusCode – 304', t => {
+status('should send empty response content when is `304` code', () => {
 	let res = new Response();
 	send(res, 304);
-	t.is(res.statusCode, 304, 'set statusCode: 304');
-	t.is(res.getHeaderNames().length, 0, 'custom headers added: 0');
-	t.false(res.hasHeader(TYPE), '~> removes header[type]');
-	t.false(res.hasHeader(LENGTH), '~> removes header[length]');
-	t.is(res.body, '', 'empty body');
-	t.end();
+	assert.is(res.statusCode, 304, 'set statusCode: 304');
+	assert.is(res.getHeaderNames().length, 0, 'custom headers added: 0');
+	assert.not(res.hasHeader(TYPE), '~> removes header[type]');
+	assert.not(res.hasHeader(LENGTH), '~> removes header[length]');
+	assert.is(res.body, '', 'empty body');
 });
 
-test('(send) HEAD – String', t => {
+status.run();
+
+// ---
+
+const HEAD = suite('HEAD');
+
+HEAD('with String', () => {
 	let str = 'FOOBAR';
 	let method = 'HEAD';
 	let res = new Response({ method });
 	send(res, 200, str);
-	t.is(res.statusCode, 200, 'set statusCode: 200');
-	t.is(res.getHeaderNames().length, 2, 'custom headers added: 2');
-	t.is(res.getHeader(TYPE), 'text/plain', 'custom header[type]: text/plain');
-	t.is(res.getHeader(LENGTH), str.length, `custom header[length]: ${str.length}`);
-	t.is(res.body, '', 'empty body');
-	t.end();
+	assert.is(res.statusCode, 200, 'set statusCode: 200');
+	assert.is(res.getHeaderNames().length, 2, 'custom headers added: 2');
+	assert.is(res.getHeader(TYPE), 'text/plain', 'custom header[type]: text/plain');
+	assert.is(res.getHeader(LENGTH), str.length, `custom header[length]: ${str.length}`);
+	assert.is(res.body, '', 'empty body');
 });
 
-test('(send) HEAD – Object', t => {
+HEAD('with Object', () => {
 	let method = 'HEAD';
 	let obj = { foo:123, bar:456 };
 	let res = new Response({ method });
 	let str = JSON.stringify(obj);
+
+	// @ts-ignore - TODO: types
 	send(res, 200, obj);
-	t.is(res.statusCode, 200, 'set statusCode: 200');
-	t.is(res.getHeaderNames().length, 2, 'custom headers added: 2');
-	t.is(res.getHeader(TYPE), 'application/json; charset=utf-8', 'custom header[type]: application/json');
-	t.is(res.getHeader(LENGTH), str.length, `custom header[length]: ${str.length}`);
-	t.is(res.body, '', 'empty body');
-	t.end();
+	assert.is(res.statusCode, 200, 'set statusCode: 200');
+	assert.is(res.getHeaderNames().length, 2, 'custom headers added: 2');
+	assert.is(res.getHeader(TYPE), 'application/json; charset=utf-8', 'custom header[type]: application/json');
+	assert.is(res.getHeader(LENGTH), str.length, `custom header[length]: ${str.length}`);
+	assert.is(res.body, '', 'empty body');
 });
 
-test('(send) body – String', t => {
+HEAD.run();
+
+// ---
+
+const Strings = suite('body/String');
+
+Strings('should handle String content', () => {
 	let str = 'FOOBAR';
 	let res = new Response();
 	send(res, 405, str);
-	t.is(res.statusCode, 405, 'set statusCode: 405');
-	t.is(res.getHeaderNames().length, 2, 'custom headers added: 2');
-	t.is(res.getHeader(TYPE), 'text/plain', 'custom header[type]: text/plain');
-	t.is(res.getHeader(LENGTH), str.length, `custom header[length]: ${str.length}`);
-	t.is(res.body, str, `custom body: ${str}`);
-	t.end();
+	assert.is(res.statusCode, 405, 'set statusCode: 405');
+	assert.is(res.getHeaderNames().length, 2, 'custom headers added: 2');
+	assert.is(res.getHeader(TYPE), 'text/plain', 'custom header[type]: text/plain');
+	assert.is(res.getHeader(LENGTH), str.length, `custom header[length]: ${str.length}`);
+	assert.is(res.body, str, `custom body: ${str}`);
 });
 
-test('(send) body – Object', t => {
+Strings.run();
+
+// ---
+
+const Objects = suite('body/Object');
+
+Objects('should handle Object content', () => {
 	let res = new Response();
 	let obj = { foo:123, bar:456 };
 	let str = JSON.stringify(obj);
+	// @ts-ignore - TODO: types
 	send(res, 200, obj); // send object
-	t.is(res.statusCode, 200, 'set statusCode: 200');
-	t.is(res.getHeaderNames().length, 2, 'custom headers added: 2');
-	t.is(res.getHeader(TYPE), 'application/json; charset=utf-8', 'custom header[type]: application/json');
-	t.is(res.getHeader(LENGTH), str.length, `custom header[length]: ${str.length}`);
-	t.is(res.body, str, `custom body: ${str} (as JSON string)`);
-	t.end();
+	assert.is(res.statusCode, 200, 'set statusCode: 200');
+	assert.is(res.getHeaderNames().length, 2, 'custom headers added: 2');
+	assert.is(res.getHeader(TYPE), 'application/json; charset=utf-8', 'custom header[type]: application/json');
+	assert.is(res.getHeader(LENGTH), str.length, `custom header[length]: ${str.length}`);
+	assert.is(res.body, str, `custom body: ${str} (as JSON string)`);
 });
 
-test('(send) body – Buffer', t => {
+Objects.run();
+
+// ---
+
+const Buffers = suite('body/buffer');
+
+Buffers('should handle Buffer content', () => {
 	let res = new Response();
 	let str = Buffer.from('foobar');
+	// @ts-ignore - TODO: types
 	send(res, 200, str);
-	t.is(res.statusCode, 200, 'set statusCode: 200');
-	t.is(res.getHeaderNames().length, 2, 'custom headers added: 2');
-	t.is(res.getHeader(TYPE), 'application/octet-stream', 'custom header[type]: application/octet-stream');
-	t.is(res.getHeader(LENGTH), str.length, `custom header[length]: ${str.length}`);
-	t.is(res.body, str, `custom body: ${str} (as JSON string)`);
-	t.end();
+	assert.is(res.statusCode, 200, 'set statusCode: 200');
+	assert.is(res.getHeaderNames().length, 2, 'custom headers added: 2');
+	assert.is(res.getHeader(TYPE), 'application/octet-stream', 'custom header[type]: application/octet-stream');
+	assert.is(res.getHeader(LENGTH), str.length, `custom header[length]: ${str.length}`);
+	assert.is(res.body, str, `custom body: ${str} (as JSON string)`);
 });
 
-test('(send) headers – String', t => {
+Buffers.run();
+
+// ---
+
+const headers = suite('headers');
+
+headers('String', () => {
 	let str = 'Hello';
 	let res = new Response();
 	send(res, 500, str, {
@@ -143,85 +175,93 @@ test('(send) headers – String', t => {
 		'x-foo': 'hello',
 		'x-bar': 'world'
 	});
-	t.is(res.statusCode, 500, 'set statusCode: 500');
-	t.is(res.getHeaderNames().length, 4, 'total headers added: 4');
-	t.is(res.getHeader(TYPE), 'foo/bar', 'custom header[type]: foo/bar');
-	t.is(res.getHeader(LENGTH), str.length, `custom header[length]: ${str.length}`);
-	t.is(res.getHeader('x-foo'), 'hello', 'custom header[x-foo]: hello');
-	t.is(res.getHeader('x-bar'), 'world', 'custom header[x-bar]: world');
-	t.is(res.body, str, `custom body: ${str}`);
-	t.end();
+	assert.is(res.statusCode, 500, 'set statusCode: 500');
+	assert.is(res.getHeaderNames().length, 4, 'total headers added: 4');
+	assert.is(res.getHeader(TYPE), 'foo/bar', 'custom header[type]: foo/bar');
+	assert.is(res.getHeader(LENGTH), str.length, `custom header[length]: ${str.length}`);
+	assert.is(res.getHeader('x-foo'), 'hello', 'custom header[x-foo]: hello');
+	assert.is(res.getHeader('x-bar'), 'world', 'custom header[x-bar]: world');
+	assert.is(res.body, str, `custom body: ${str}`);
 });
 
-test('(send) headers – Object', t => {
+headers('Object', () => {
 	let obj = { foo:123 };
 	let str = JSON.stringify(obj);
 	let res = new Response();
+	// @ts-ignore - TODO: types
 	send(res, 500, obj, { [TYPE]:'foo/bar' });
-	t.is(res.statusCode, 500, 'set statusCode: 500');
-	t.is(res.getHeaderNames().length, 2, 'total headers added: 2');
-	t.is(res.getHeader(TYPE), 'foo/bar', 'allow Content-Type override: foo/bar');
-	t.is(res.getHeader(LENGTH), str.length, `custom header[length]: ${str.length}`);
-	t.is(res.body, str, `custom body: ${str}`);
-	t.end();
+	assert.is(res.statusCode, 500, 'set statusCode: 500');
+	assert.is(res.getHeaderNames().length, 2, 'total headers added: 2');
+	assert.is(res.getHeader(TYPE), 'foo/bar', 'allow Content-Type override: foo/bar');
+	assert.is(res.getHeader(LENGTH), str.length, `custom header[length]: ${str.length}`);
+	assert.is(res.body, str, `custom body: ${str}`);
 });
 
-test('(send) headers – Object :: case insensitive', t => {
+headers('Object :: case insensitive', () => {
 	let obj = { foo:123 };
 	let str = JSON.stringify(obj);
 
 	let foo = new Response();
+	// @ts-ignore - TODO: types
 	send(foo, 500, obj, { 'content-type':'foo/bar' });
-	t.is(foo.statusCode, 500, 'set statusCode: 500');
-	t.is(foo.getHeaderNames().length, 2, 'total headers added: 2');
-	t.is(foo.getHeader(TYPE), 'foo/bar', 'allow Content-Type override: foo/bar');
-	t.is(foo.getHeader(LENGTH), str.length, `custom header[length]: ${str.length}`);
-	t.is(foo.body, str, `custom body: ${str}`);
+	assert.is(foo.statusCode, 500, 'set statusCode: 500');
+	assert.is(foo.getHeaderNames().length, 2, 'total headers added: 2');
+	assert.is(foo.getHeader(TYPE), 'foo/bar', 'allow Content-Type override: foo/bar');
+	assert.is(foo.getHeader(LENGTH), str.length, `custom header[length]: ${str.length}`);
+	assert.is(foo.body, str, `custom body: ${str}`);
 
 	let bar = new Response();
+	// @ts-ignore - TODO: types
 	send(bar, 500, obj, { 'cOnTeNt-TyPe':'foo/bar' });
-	t.is(bar.statusCode, 500, 'set statusCode: 500');
-	t.is(bar.getHeaderNames().length, 2, 'total headers added: 2');
-	t.is(bar.getHeader(TYPE), 'foo/bar', 'allow Content-Type override: foo/bar');
-	t.is(bar.getHeader(LENGTH), str.length, `custom header[length]: ${str.length}`);
-	t.is(bar.body, str, `custom body: ${str}`);
+	assert.is(bar.statusCode, 500, 'set statusCode: 500');
+	assert.is(bar.getHeaderNames().length, 2, 'total headers added: 2');
+	assert.is(bar.getHeader(TYPE), 'foo/bar', 'allow Content-Type override: foo/bar');
+	assert.is(bar.getHeader(LENGTH), str.length, `custom header[length]: ${str.length}`);
+	assert.is(bar.body, str, `custom body: ${str}`);
 
-	t.end();
 });
 
-test('(send) headers – Object :: respect existing', t => {
+headers('Object :: respect existing', () => {
 	let obj = { foo:123 };
 	let str = JSON.stringify(obj);
 	let res = new Response();
 	res.setHeader('Content-Type', 'custom/type');
+	// @ts-ignore - TODO: types
 	send(res, 500, obj);
-	t.is(res.statusCode, 500, 'set statusCode: 500');
-	t.is(res.getHeaderNames().length, 2, 'total headers added: 2');
-	t.is(res.getHeader(TYPE), 'custom/type', 'reuse Content-Type from header: custom/type');
-	t.is(res.getHeader(LENGTH), str.length, `custom header[length]: ${str.length}`);
-	t.is(res.body, str, `custom body: ${str}`);
-	t.end();
+	assert.is(res.statusCode, 500, 'set statusCode: 500');
+	assert.is(res.getHeaderNames().length, 2, 'total headers added: 2');
+	assert.is(res.getHeader(TYPE), 'custom/type', 'reuse Content-Type from header: custom/type');
+	assert.is(res.getHeader(LENGTH), str.length, `custom header[length]: ${str.length}`);
+	assert.is(res.body, str, `custom body: ${str}`);
 });
 
-test('(send) headers – Buffer', t => {
+headers('Buffer', () => {
 	let str = Buffer.from('hello');
 	let res = new Response();
+	// @ts-ignore - TODO: types
 	send(res, 200, str, { [TYPE]: 'foo/bar' });
-	t.is(res.statusCode, 200, 'set statusCode: 200');
-	t.is(res.getHeaderNames().length, 2, 'total headers added: 2');
-	t.is(res.getHeader(TYPE), 'foo/bar', 'prefer provided header[type] value: foo/bar');
-	t.is(res.getHeader(LENGTH), str.length, `custom header[length]: ${str.length}`);
-	t.is(res.body, str, `custom body: ${str}`);
-	t.end();
+	assert.is(res.statusCode, 200, 'set statusCode: 200');
+	assert.is(res.getHeaderNames().length, 2, 'total headers added: 2');
+	assert.is(res.getHeader(TYPE), 'foo/bar', 'prefer provided header[type] value: foo/bar');
+	assert.is(res.getHeader(LENGTH), str.length, `custom header[length]: ${str.length}`);
+	assert.is(res.body, str, `custom body: ${str}`);
 });
 
-test('(send) body – Stream', t => {
-	t.plan(5);
+headers.run();
+
+// ---
+
+const Streams = suite('body/stream');
+
+Streams('should handle piped Stream-like responses', async () => {
+	let buffer = '';
+	let rr = fs.createReadStream(INPUT);
 
 	// "Response" stand-in (accepts pipe)
 	let output = join(__dirname, 'out.js');
-	let rw = fs.createWriteStream(output).on('pipe', x => {
-		t.is(x.constructor.name, 'ReadStream', '~> "response" receives the pipe');
+	let rw = fs.createWriteStream(output).on('pipe', stream => {
+		assert.is(stream.constructor.name, 'ReadStream', '~> "response" receives the pipe');
+		stream.on('data', x => { buffer += x });
 	});
 
 	rw.headers = {};
@@ -233,30 +273,29 @@ test('(send) body – Stream', t => {
 	rw.getHeader = (key) => {
 		return rw.headers[key];
 	};
-
-	let rr = fs.createReadStream(INPUT).on('end', () => {
-		try {
-			let info = fs.statSync(output);
-			t.pass('~> "response" output exists');
-			t.true(info.size > 0, '~~> data piped successfully');
-		} catch (err) {
-			//
-		}
-		fs.unlinkSync(output); // ~> cleanup
-	});
 
 	let out = send(rw, 200, rr);
-	t.same(out, rw, 'returns the "response" to itself');
-	t.is(rw.headers[TYPE], 'application/octet-stream', 'applies `Content-Type: application/octet-stream` header');
+
+	await new Promise((res, rej) => {
+		rw.on('close', res).on('error', rej);
+	});
+
+	assert.equal(out, rw, 'returns the "response" to itself');
+	assert.is(rw.headers[TYPE], 'application/octet-stream', 'applies `Content-Type: application/octet-stream` header');
+
+	assert.ok(buffer.length > 0, '~> "response" written');
+	if (fs.existsSync(output)) fs.unlinkSync(output); // ~> cleanup
 });
 
-test('(send) body – Stream :: respect existing', t => {
-	t.plan(5);
+Streams('should respect existing headers w/ stream responses', async () => {
+	let buffer = '';
+	let rr = fs.createReadStream(INPUT);
 
 	// "Response" stand-in (accepts pipe)
 	let output = join(__dirname, 'out.js');
-	let rw = fs.createWriteStream(output).on('pipe', x => {
-		t.is(x.constructor.name, 'ReadStream', '~> "response" receives the pipe');
+	let rw = fs.createWriteStream(output).on('pipe', stream => {
+		assert.is(stream.constructor.name, 'ReadStream', '~> "response" receives the pipe');
+		stream.on('data', x => { buffer += x });
 	});
 
 	rw.headers = {};
@@ -268,62 +307,63 @@ test('(send) body – Stream :: respect existing', t => {
 	rw.getHeader = (key) => {
 		return rw.headers[key];
 	};
-
-	let rr = fs.createReadStream(INPUT).on('end', () => {
-		try {
-			let info = fs.statSync(output);
-			t.pass('~> "response" output exists');
-			t.true(info.size > 0, '~~> data piped successfully');
-		} catch (err) {
-			//
-		}
-		fs.unlinkSync(output); // ~> cleanup
-	});
-
 
 	rw.setHeader(TYPE.toLowerCase(), 'custom/stream');
 
 	let out = send(rw, 200, rr);
-	t.same(out, rw, 'returns the "response" to itself');
-	t.is(rw.headers[TYPE.toLowerCase()], 'custom/stream', 'maintains `Content-Type: custom/stream` header');
+
+	await new Promise((res, rej) => {
+		rw.on('close', res).on('error', rej);
+	});
+
+	assert.equal(out, rw, 'returns the "response" to itself');
+	assert.is(rw.headers[TYPE.toLowerCase()], 'custom/stream', 'maintains `Content-Type: custom/stream` header');
+
+	assert.ok(buffer.length > 0, '~> "response" written');
+	if (fs.existsSync(output)) fs.unlinkSync(output); // ~> cleanup
 });
 
-test('(send) ETag', t => {
+Streams.run();
+
+// ---
+
+const ETag = suite('ETag');
+
+ETag('should append "ETag" header value', () => {
 	let str = 'FOOBAR';
 	let res = new Response();
-	send(res, 200, str, { etag:true });
-	t.is(res.statusCode, 200, 'set statusCode: 200');
-	t.is(res.getHeaderNames().length, 3, 'custom headers added: 3');
-	t.is(res.getHeader(TYPE), 'text/plain', 'custom header[type]: text/plain');
-	t.is(res.getHeader(LENGTH), str.length, `custom header[length]: ${str.length}`);
-	t.is(res.getHeader('ETag'), 'W/"6-8zkP4uVUbaw9GWiXDfGiIqOjnAA"', 'custom header[ETag]: correct');
-	t.is(res.body, str, `custom body: ${str}`);
-	t.end();
+	send(res, 200, str, { etag: true });
+	assert.is(res.statusCode, 200, 'set statusCode: 200');
+	assert.is(res.getHeaderNames().length, 3, 'custom headers added: 3');
+	assert.is(res.getHeader(TYPE), 'text/plain', 'custom header[type]: text/plain');
+	assert.is(res.getHeader(LENGTH), str.length, `custom header[length]: ${str.length}`);
+	assert.is(res.getHeader('ETag'), 'W/"6-8zkP4uVUbaw9GWiXDfGiIqOjnAA"', 'custom header[ETag]: correct');
+	assert.is(res.body, str, `custom body: ${str}`);
 });
 
-test('(send) ETag – HEAD', t => {
+ETag('should still add "ETag" header to HEAD requests', () => {
 	let str = 'FOOBAR';
 	let method = 'HEAD';
 	let res = new Response({ method });
-	send(res, 200, str, { etag:true });
-	t.is(res.statusCode, 200, 'set statusCode: 200');
-	t.is(res.getHeaderNames().length, 3, 'custom headers added: 3');
-	t.is(res.getHeader(TYPE), 'text/plain', 'custom header[type]: text/plain');
-	t.is(res.getHeader(LENGTH), str.length, `custom header[length]: ${str.length}`);
-	t.is(res.getHeader('ETag'), 'W/"6-8zkP4uVUbaw9GWiXDfGiIqOjnAA"', 'custom header[ETag]: correct');
-	t.is(res.body, '', 'empty body');
-	t.end();
+	send(res, 200, str, { etag: true });
+	assert.is(res.statusCode, 200, 'set statusCode: 200');
+	assert.is(res.getHeaderNames().length, 3, 'custom headers added: 3');
+	assert.is(res.getHeader(TYPE), 'text/plain', 'custom header[type]: text/plain');
+	assert.is(res.getHeader(LENGTH), str.length, `custom header[length]: ${str.length}`);
+	assert.is(res.getHeader('ETag'), 'W/"6-8zkP4uVUbaw9GWiXDfGiIqOjnAA"', 'custom header[ETag]: correct');
+	assert.is(res.body, '', 'empty body');
 });
 
-test('(send) ETag – 204', t => {
+ETag('should still add "ETag" header to `204` responses', () => {
 	let str = 'FOOBAR';
 	let res = new Response();
-	send(res, 204, str, { etag:true });
-	t.is(res.statusCode, 204, 'set statusCode: 204');
-	t.is(res.getHeaderNames().length, 1, 'custom headers added: 1');
-	t.false(res.hasHeader(TYPE), '~> removes header[type]');
-	t.false(res.hasHeader(LENGTH), '~> removes header[length]');
-	t.is(res.getHeader('ETag'), 'W/"6-8zkP4uVUbaw9GWiXDfGiIqOjnAA"', 'custom header[ETag]: correct');
-	t.is(res.body, '', 'empty body');
-	t.end();
+	send(res, 204, str, { etag: true });
+	assert.is(res.statusCode, 204, 'set statusCode: 204');
+	assert.is(res.getHeaderNames().length, 1, 'custom headers added: 1');
+	assert.not(res.hasHeader(TYPE), '~> removes header[type]');
+	assert.not(res.hasHeader(LENGTH), '~> removes header[length]');
+	assert.is(res.getHeader('ETag'), 'W/"6-8zkP4uVUbaw9GWiXDfGiIqOjnAA"', 'custom header[ETag]: correct');
+	assert.is(res.body, '', 'empty body');
 });
+
+ETag.run();


### PR DESCRIPTION
Migrating from `tape` + `tap-spec` to [`uvu`](https://github.com/lukeed/uvu) 🎉 

> **Important:** Tests are counted differently. <br>Tape counts individual assertions, whereas `uvu` counts test blocks (having many assertions each). <br>No tests were removed & coverage is unaffected~!

***Before (`tape`)***

<img width="246" alt="Screen Shot 2020-07-16 at 11 51 37 AM" src="https://user-images.githubusercontent.com/5855893/87720710-38b3f500-c76a-11ea-9014-bbb5e1b24483.png">

***After (`uvu`)***

<img width="440" alt="Screen Shot 2020-07-16 at 1 37 53 PM" src="https://user-images.githubusercontent.com/5855893/87720738-42d5f380-c76a-11ea-8cee-db6fe8fcdd8c.png">

> **Note:** The `Done in` time includes the `pretest` script (lerna + eslint) for both.