### PR TITLE
@polka/send-type does not set HTTP status code for streams

### DIFF
--- a/packages/send-type/index.js
+++ b/packages/send-type/index.js
@@ -12,8 +12,8 @@ module.exports = function (res, code=200, data='', headers={}) {
 	let type = obj[TYPE] || res.getHeader(TYPE);
 
 	if (!!data && typeof data.pipe === 'function') {
-		res.writeHead(code, obj);
 		res.setHeader(TYPE, type || OSTREAM);
+		res.writeHead(code, obj);
 		return data.pipe(res);
 	}
 

--- a/packages/send-type/index.js
+++ b/packages/send-type/index.js
@@ -12,6 +12,7 @@ module.exports = function (res, code=200, data='', headers={}) {
 	let type = obj[TYPE] || res.getHeader(TYPE);
 
 	if (!!data && typeof data.pipe === 'function') {
+		res.writeHead(code, obj);
 		res.setHeader(TYPE, type || OSTREAM);
 		return data.pipe(res);
 	}

--- a/packages/send-type/index.js
+++ b/packages/send-type/index.js
@@ -13,7 +13,9 @@ module.exports = function (res, code=200, data='', headers={}) {
 
 	if (!!data && typeof data.pipe === 'function') {
 		res.setHeader(TYPE, type || OSTREAM);
-		res.writeHead(code, obj);
+		if (typeof res.writeHead === 'function') {
+			res.writeHead(code, obj);
+		}
 		return data.pipe(res);
 	}
 

--- a/packages/send-type/index.js
+++ b/packages/send-type/index.js
@@ -13,9 +13,7 @@ module.exports = function (res, code=200, data='', headers={}) {
 
 	if (!!data && typeof data.pipe === 'function') {
 		res.setHeader(TYPE, type || OSTREAM);
-		if (typeof res.writeHead === 'function') {
-			res.writeHead(code, obj);
-		}
+		res.writeHead(code, obj);
 		return data.pipe(res);
 	}
 

--- a/tests/send-type.js
+++ b/tests/send-type.js
@@ -152,6 +152,11 @@ test('polka/send-type::usage (Stream)', t => {
 		return rw.headers[key];
 	};
 
+	rw.writeHead = (code, obj) => {
+		rw.code = code;
+		rw.headers = Object.assign({}, rw.headers, obj);
+	};
+
 	let rr = fs.createReadStream(input).on('end', () => {
 		try {
 			let info = fs.statSync(output);
@@ -187,6 +192,11 @@ test('polka/send-type::usage (Stream – respect existing header)', t => {
 
 	rw.getHeader = (key) => {
 		return rw.headers[key];
+	};
+
+	rw.writeHead = (code, obj) => {
+		rw.code = code;
+		rw.headers = Object.assign({}, rw.headers, obj);
 	};
 
 	let rr = fs.createReadStream(input).on('end', () => {


### PR DESCRIPTION
When trying to implement range requests (status 206), I noticed that the `@polka/send-type` module does not set the supplied HTTP status code.

I just added the call to res.writeHead(), but I am not sure this is the proper way to fix this. However, this fixed the issue for me.