### PR TITLE
Add optional error parameter to listencallback

### DIFF
--- a/packages/polka/index.d.ts
+++ b/packages/polka/index.d.ts
@@ -4,7 +4,7 @@ import type { ParsedURL } from '@polka/url';
 import type Trouter from 'trouter';
 
 type Promisable<T> = Promise<T> | T;
-type ListenCallback = () => Promisable<void>;
+type ListenCallback = (err?: string | IError) => Promisable<void>;
 
 export interface IError extends Error {
 	code?: number;


### PR DESCRIPTION
There seems to be a clear conflict with the typings and the documentation. I have already created an issue about this on Sapper template repository (https://github.com/sveltejs/sapper-template/issues/311) but after a more detailed look it seems that the root reason is caused by this typing error.

In README.md example it shows that it is possible to pass an error parameter to the listencallback but the current version of types doesn't have that. This PR adds that but I am not sure if the type I gave it is correct at all. I copied it from other error handlers.