### PR TITLE
break(url): handle decodes correctly; trim `ParsedURL` properties

### DIFF
--- a/packages/polka/index.d.ts
+++ b/packages/polka/index.d.ts
@@ -24,11 +24,14 @@ export interface IOptions<T extends Request = Request> {
 
 export type Response = ServerResponse;
 
-export interface Request extends IncomingMessage, ParsedURL {
+export interface Request extends IncomingMessage {
 	url: string;
 	method: string;
 	originalUrl: string;
 	params: Record<string, string>;
+	path: string;
+	search: string;
+	query: Record<string,string>;
 	body?: any;
 	_decoded?: true;
 	_parsedUrl: ParsedURL;

--- a/packages/polka/index.js
+++ b/packages/polka/index.js
@@ -1,6 +1,6 @@
 import http from 'http';
 import Router from 'trouter';
-import parser from '@polka/url';
+import { parse } from '@polka/url';
 
 function onError(err, req, res) {
 	let code = (res.statusCode = err.code || err.status || 500);
@@ -13,7 +13,7 @@ const mount = fn => fn instanceof Polka ? fn.attach : fn;
 class Polka extends Router {
 	constructor(opts={}) {
 		super();
-		this.parse = parser;
+		this.parse = parse;
 		this.server = opts.server;
 		this.handler = this.handler.bind(this);
 		this.onError = opts.onError || onError; // catch-all handler

--- a/packages/polka/index.js
+++ b/packages/polka/index.js
@@ -45,9 +45,9 @@ class Polka extends Router {
 				},
 				fns.map(mount),
 				(req, _, next) => {
-					req.url = req._parsedUrl.href;
 					req.path = req._parsedUrl.pathname;
-					next()
+					req.url = req.path + req._parsedUrl.search;
+					next();
 				}
 			);
 		}
@@ -66,6 +66,7 @@ class Polka extends Router {
 
 		req.params = obj.params;
 		req.originalUrl = req.originalUrl || req.url;
+		req.url = info.pathname + info.search;
 		req.query = info.query || {};
 		req.search = info.search;
 

--- a/packages/polka/test/index.js
+++ b/packages/polka/test/index.js
@@ -825,7 +825,7 @@ if (hasNamedGroups) {
 					assert.is(req.path, '/comments', '~> sees correct `path` value – REPLACED PATTERN');
 					assert.is(req.url, '/comments?foo', '~> sees correct `url` value – REPLACED PATTERN');
 					assert.is(req.params.title, 'narnia', '~> receives correct `params.title` value');
-					assert.equal(req.query, { foo: '' }, '~> receives correct `req.query` value');
+					assert.equal({ ...req.query }, { foo: '' }, '~> receives correct `req.query` value');
 					res.end('cya~!');
 				}) // global
 				.use(/^\/songs.*/i, (req, res) => {
@@ -1042,7 +1042,7 @@ test('sub-application', async () => {
 				assert.ok('runs the sub-application /:id route');
 				assert.is(req.params.bar, 'hi', '~> parses the sub-application params');
 				assert.is(req.url, '/hi?a=0', '~> trims basepath from `req.url` value');
-				assert.equal(req.query, {a:'0'}, '~> parses the sub-application `res.query` value');
+				assert.equal({ ...req.query }, { a:'0' }, '~> parses the sub-application `res.query` value');
 				assert.is(req.originalUrl, '/sub/hi?a=0', '~> preserves original `req.url` value');
 				assert.is(req.foo, 'hello', '~> receives mutatations from main-app middleware');
 				assert.is(req.bar, 'world', '~> receives mutatations from own middleware');
@@ -1095,7 +1095,7 @@ test('sub-application w/ query params', async () => {
 				assert.ok('runs the sub-application / route');
 				assert.is(req.url, '/?foo=bar', '~> trims basepath from `req.url` value');
 				assert.is(req.originalUrl, '/sub?foo=bar', '~> preserves original `req.url` value');
-				assert.equal(req.query, { foo: 'bar' }, '~> preserves original `req.query` value');
+				assert.equal({ ...req.query }, { foo: 'bar' }, '~> preserves original `req.query` value');
 				res.end('hello from sub@index');
 			})
 	);
@@ -1107,7 +1107,7 @@ test('sub-application w/ query params', async () => {
 				assert.ok('run the main-application route');
 				assert.is(req.url, '/?foo=123', '~> always sets `req.originalUrl` key');
 				assert.is(req.originalUrl, '/?foo=123', '~> always sets `req.originalUrl` key');
-				assert.equal(req.query, { foo: '123' }, '~> sets the `req.query` value');
+				assert.equal({ ...req.query }, { foo: '123' }, '~> sets the `req.query` value');
 				res.end('hello from main');
 			})
 	);
@@ -1388,7 +1388,7 @@ test('decode url', async () => {
 				assert.ok('~> inside "GET /sub/:foo" handler')
 				assert.ok(req._decoded, '~> marked as decoded');
 				assert.is(req.path, '/føøß∂r', '~> decoded "path" value');
-				assert.is(req.url, '/føøß∂r?phone=+8675309', '~> decoded "url" value fully');
+				assert.is(req.url, '/føøß∂r?phone=%2b8675309', '~> decoded "url" value partially');
 				assert.is(req.params.foo, 'føøß∂r', '~> decoded "params.foo" segment');
 				assert.is(req.query.phone, '+8675309', '~~> does NOT decode "req.query" keys twice');
 				res.end('done');

--- a/packages/url/bench/index.js
+++ b/packages/url/bench/index.js
@@ -1,3 +1,4 @@
+/* eslint-disable no-console */
 const native = require('url');
 const qs = require('querystring');
 const assert = require('uvu/assert');
@@ -92,7 +93,7 @@ function runner(config) {
 			console.log('  ✔', name);
 		} catch (err) {
 			console.log('  ✘', name, `(FAILED @ "${key}")`);
-		 	if (isVerbose) console.log(err.details);
+			if (isVerbose) console.log(err.details);
 		}
 	});
 

--- a/packages/url/bench/package.json
+++ b/packages/url/bench/package.json
@@ -1,6 +1,8 @@
 {
   "private": true,
   "devDependencies": {
+    "@types/benchmark": "2.1.0",
+    "@types/parseurl": "1.3.1",
     "benchmark": "2.1.4",
     "parseurl": "1.3.2"
   }

--- a/packages/url/bench/raw.js
+++ b/packages/url/bench/raw.js
@@ -1,0 +1,73 @@
+/**
+ * NO NORMALIZATION ATTEMPTS MADE
+ * AKA: All candidates different / no validations
+ */
+
+const native = require('url');
+const qs = require('querystring');
+const assert = require('uvu/assert');
+const { Suite } = require('benchmark');
+
+const polka = require('../build').parse;
+const parseurl = require('parseurl');
+
+/**
+ * @typedef Request
+ * @property {string} url
+ */
+
+/**
+ * @typedef Contender
+ * @type {(req: Request) => any}
+ */
+
+/**
+ * All benchmark candidates!
+ * @NOTE Some are modified for decoding validation
+ * @type {Record<string, Contender>}
+ */
+const contenders = {
+	'url.parse#1': r => native.parse(r.url, true),
+	'url.parse#2': r => native.parse(r.url, false),
+
+	'new URL()': r => new URL(r.url, 'http://x'),
+
+	// @ts-ignore - r type
+	'parseurl': r => parseurl(r),
+
+	// @ts-ignore - r type
+	'@polka/url': r => polka(r),
+};
+
+/**
+ * @param {string} url
+ * @param {boolean} [toRepeat]
+ */
+function runner(url, toRepeat) {
+	let title = toRepeat ? 'repeat' : 'normal';
+
+	console.log('\nBenchmark: (%s) "%s"', title, url);
+	let bench = new Suite().on('cycle', e => {
+		console.log('  ' + e.target);
+	});
+
+	Object.keys(contenders).forEach(name => {
+		let fn = contenders[name];
+		let req = toRepeat && { url };
+
+		bench.add(name + ' '.repeat(16 - name.length), () => {
+			fn(req || { url });
+		}, {
+			minSamples: 100
+		});
+	});
+
+	bench.run();
+}
+
+// ---
+
+runner('/foo/bar?user=tj&pet=fluffy');
+runner('/foo/bar?user=tj&pet=fluffy', true);
+runner('/foo/bar');
+runner('/');

--- a/packages/url/bench/raw.js
+++ b/packages/url/bench/raw.js
@@ -1,11 +1,11 @@
+/* eslint-disable no-console */
+
 /**
  * NO NORMALIZATION ATTEMPTS MADE
  * AKA: All candidates different / no validations
  */
 
 const native = require('url');
-const qs = require('querystring');
-const assert = require('uvu/assert');
 const { Suite } = require('benchmark');
 
 const polka = require('../build').parse;

--- a/packages/url/bench/readme.md
+++ b/packages/url/bench/readme.md
@@ -1,104 +1,75 @@
 ## Benchmarks
 
-> Run on Node v10.13.0
+> Running on Node v14.15.3
+
+***Modifications:***
+
+Each candidate is _slightly_ modified to match the `pathname` and `query` values that `@polka/url` returns. This is done in an honest/best-effort manner to normalize all candidates (and pass the validation steps), especially considering that the typical user _wants_ `pathname`s to be normalized and _wants_ `query` values to be parsed (and decoded) into an object.
+
 
 ### Without Decoding
 
-All candidates process the `url` as is & return (nearly) identical outputs.
-
-***Differences:***
-
-* Both `parseurl` and `@polka/url` include a `_raw` key
-* Both `parseurl` and `@polka/url` mutate the `req` object for memoization on repeat calls
-* Since Node.js `http.Server` only receives pathing segments, `@polka/url` does not bother including:
-  * `protocol`
-  * `slashes`
-  * `auth`
-  * `host`
-  * `port`
-  * `hostname`
-  * `hash`
-
-***Results:***
+> **Important:** All candidates listed pass validation – sometimes due to normalization.
 
 ```
-# Parsing: "/foo/bar?user=tj&pet=fluffy"
-  native       x  4,253,173 ops/sec ±0.68% (192 runs sampled)
-  parseurl     x  8,070,055 ops/sec ±0.17% (196 runs sampled)
-  @polka/url   x 30,073,280 ops/sec ±3.09% (194 runs sampled)
+Benchmark: "/foo/bar?user=tj&pet=fluffy"
+  url.parse        x   1,437,988 ops/sec ±0.15% (193 runs sampled)
+  new URL()        x     258,158 ops/sec ±0.17% (193 runs sampled)
+  parseurl         x   2,074,250 ops/sec ±0.22% (193 runs sampled)
+  @polka/url       x   2,584,006 ops/sec ±0.26% (194 runs sampled)
 
-# REPEAT: "/foo/bar?user=tj&pet=fluffy"
-  native       x   4,264,907 ops/sec ±0.22% (194 runs sampled)
-  parseurl     x 141,602,256 ops/sec ±0.27% (194 runs sampled)
-  @polka/url   x 221,088,023 ops/sec ±0.15% (195 runs sampled)
+Benchmark: (REPEAT) "/foo/bar?user=tj&pet=fluffy"
+  url.parse        x   1,457,258 ops/sec ±0.17% (193 runs sampled)
+  new URL()        x     257,459 ops/sec ±0.24% (189 runs sampled)
+  parseurl         x  26,687,772 ops/sec ±0.40% (192 runs sampled)
+  @polka/url       x 117,737,558 ops/sec ±0.23% (193 runs sampled)
 
-# Parsing: "/foo/bar"
-  native       x 10,114,439 ops/sec ±0.49% (194 runs sampled)
-  parseurl     x 26,714,707 ops/sec ±0.15% (194 runs sampled)
-  @polka/url   x 67,833,366 ops/sec ±0.30% (194 runs sampled)
+Benchmark: "/foo/bar"
+  url.parse        x   5,928,214 ops/sec ±0.33% (191 runs sampled)
+  new URL()        x     290,799 ops/sec ±0.17% (192 runs sampled)
+  parseurl         x  17,597,099 ops/sec ±0.62% (189 runs sampled)
+  @polka/url       x  34,097,146 ops/sec ±0.55% (192 runs sampled)
 
-# Parsing: "/"
-  native       x 16,811,257 ops/sec ±0.25% (190 runs sampled)
-  parseurl     x 36,045,298 ops/sec ±0.27% (192 runs sampled)
-  @polka/url   x 68,199,005 ops/sec ±0.25% (195 runs sampled)
+Benchmark: "/"
+  url.parse        x   8,933,877 ops/sec ±0.70% (190 runs sampled)
+  new URL()        x     333,268 ops/sec ±0.19% (193 runs sampled)
+  parseurl         x  27,358,354 ops/sec ±0.76% (188 runs sampled)
+  @polka/url       x  43,529,456 ops/sec ±1.99% (172 runs sampled)
 ```
-
 
 
 ### With Decoding
 
-All candidates must decode the incoming `url` and return value segments as decoded strings, too.<br>
-Similarly, the `query` key must be parsed into an Object whose keys & values are also decoded.
-
-> **Important:** The `parseurl`, `native/bad#1`, and `native/bad#2` candidates are "unofficial" implementations.
-
-* `native/bad#1` uses [`url.parse`](https://nodejs.org/api/url.html#url_url_parse_urlstring_parsequerystring_slashesdenotehost) with `parseQueryString` enabled<br>
-    _It decodes the `query` correctly, but all other segments are still encoded segments._
-
-* `native/bad#2` is the same as `native/bad#1` except it passes thru `decodeURIComponent` first<br>
-    _It **double-decodes** the `query`, allowing you to lose characters!_
-
-* `parseurl` does not handle decoding for you<br>
-    _You have the same dilemma and inconsistencies of `native/bad#1` and `native/bad#2` too._<br>
-    _However, this candidate takes an approach to rectify the output._
-
-```js
-// Example of inconsistencies:
-// ~> native/bad#1, native/bad#2, parseurl
-
-const demo = '/f%C3%B8%C3%B8?phone=%2b8675309';
-// Desired: '/føø?phone=+8675309'
-
-url.parse(demo, true);
-// (right) query => { phone: '+8675309' }
-// (wrong) pathname => '/f%C3%B8%C3%B8'
-
-url.parse(decodeURIComponent(demo), true);
-// (wrong) query => { phone: ' 8675309' }
-// (right) pathname => '/føø'
-```
-
-***Results:***
+> **Important:** All candidates listed pass validation – sometimes due to normalization.
 
 ```
-# DECODE: "/f%C3%B8%C3%B8%C3%9F%E2%88%82r"
-  native/bad#1   x 4,388,726 ops/sec ±0.62% (191 runs sampled)
-  native/bad#2   x 1,332,192 ops/sec ±0.36% (192 runs sampled)
-  native         x   588,862 ops/sec ±0.37% (194 runs sampled)
-  parseurl       x   625,776 ops/sec ±0.13% (194 runs sampled)
-  @polka/url     x 1,638,012 ops/sec ±0.36% (194 runs sampled)
+Benchmark: "/f%C3%B8%C3%B8%C3%9F%E2%88%82r"
+  url.parse        x   1,038,724 ops/sec ±0.12% (193 runs sampled)
+  new URL()        x     229,125 ops/sec ±0.17% (192 runs sampled)
+  parseurl         x   1,370,300 ops/sec ±0.20% (192 runs sampled)
+  @polka/url       x   1,540,894 ops/sec ±0.18% (192 runs sampled)
 
-# DECODE: "/f%C3%B8%C3%B8%C3%9F%E2%88%82r?phone=%2b393383123549"
-  native/bad#1   x 267,614 ops/sec ±0.37% (193 runs sampled)
-  native/bad#2   x 239,160 ops/sec ±0.34% (193 runs sampled)
-  native         x 176,155 ops/sec ±0.32% (194 runs sampled)
-  parseurl       x 179,706 ops/sec ±0.28% (194 runs sampled)
-  @polka/url     x 671,500 ops/sec ±0.30% (193 runs sampled)
+Benchmark: "/f%C3%B8%C3%B8%C3%9F%E2%88%82r?phone=%2b393383123549"
+  url.parse        x     514,280 ops/sec ±0.40% (193 runs sampled)
+  new URL()        x     187,672 ops/sec ±0.67% (192 runs sampled)
+  parseurl         x     618,801 ops/sec ±0.10% (189 runs sampled)
+  @polka/url       x     696,125 ops/sec ±0.14% (191 runs sampled)
 
-# DECODE: "/foo/bar"
-  native/bad#1   x  9,230,890 ops/sec ±0.88% (193 runs sampled)
-  native/bad#2   x  1,906,574 ops/sec ±0.24% (192 runs sampled)
-  native         x    891,891 ops/sec ±0.34% (194 runs sampled)
-  parseurl       x    927,090 ops/sec ±0.13% (194 runs sampled)
-  @polka/url     x 34,007,102 ops/sec ±1.40% (193 runs sampled)
-````
+Benchmark: (REPEAT) "/f%C3%B8%C3%B8%C3%9F%E2%88%82r?phone=%2b393383123549"
+  url.parse        x     425,909 ops/sec ±0.29% (193 runs sampled)
+  new URL()        x     187,735 ops/sec ±0.14% (194 runs sampled)
+  parseurl         x   1,770,147 ops/sec ±0.15% (193 runs sampled)
+  @polka/url       x 197,963,726 ops/sec ±0.18% (194 runs sampled)
+
+Benchmark: "/foo/bar?hello=123"
+  url.parse        x   1,133,709 ops/sec ±0.28% (190 runs sampled)
+  new URL()        x     236,384 ops/sec ±0.20% (193 runs sampled)
+  parseurl         x   1,431,879 ops/sec ±0.19% (191 runs sampled)
+  @polka/url       x   3,883,489 ops/sec ±0.37% (192 runs sampled)
+
+Benchmark: "/foo/bar"
+  url.parse        x   1,824,376 ops/sec ±0.54% (192 runs sampled)
+  new URL()        x     252,204 ops/sec ±0.18% (192 runs sampled)
+  parseurl         x   2,329,132 ops/sec ±0.26% (193 runs sampled)
+  @polka/url       x  19,972,200 ops/sec ±0.64% (188 runs sampled)
+```

--- a/packages/url/index.d.ts
+++ b/packages/url/index.d.ts
@@ -8,4 +8,4 @@ export interface ParsedURL {
 	raw: string;
 }
 
-export default function (req: IncomingMessage, toDecode?: boolean): ParsedURL;
+export function parse(req: IncomingMessage, toDecode?: boolean): ParsedURL;

--- a/packages/url/index.d.ts
+++ b/packages/url/index.d.ts
@@ -1,12 +1,11 @@
 import type { IncomingMessage } from 'http';
+import type { ParsedUrlQuery } from 'querystring';
 
 export interface ParsedURL {
-	path: string;
 	pathname: string;
-	search: string | null;
-	query: Record<string, string | string[]> | string | null;
-	href: string;
-	_raw: string;
+	search: string;
+	query: Record<string, string | string[]> | void;
+	raw: string;
 }
 
 export default function (req: IncomingMessage, toDecode?: boolean): ParsedURL;

--- a/packages/url/index.js
+++ b/packages/url/index.js
@@ -17,7 +17,7 @@ import * as qs from 'querystring';
  * @param {boolean} [toDecode]
  * @returns {ParsedURL|void}
  */
-export default function (req, toDecode) {
+export function parse(req, toDecode) {
 	let raw = req.url;
 	if (raw == null) return;
 

--- a/packages/url/index.js
+++ b/packages/url/index.js
@@ -1,50 +1,50 @@
-function parse(str) {
-	let i=0, j=0, k, v;
-	let out={}, arr=str.split('&');
-	for (; i < arr.length; i++) {
-		j = arr[i].indexOf('=');
-		v = !!~j && arr[i].substring(j+1) || '';
-		k = !!~j ? arr[i].substring(0, j) : arr[i];
-		out[k] = out[k] !== void 0 ? [].concat(out[k], v) : v;
-	}
-	return out;
-}
+import * as qs from 'querystring';
 
+/**
+ * @typedef ParsedURL
+ * @type {import('.').ParsedURL}
+ */
+
+/**
+ * @typedef Request
+ * @property {string} url
+ * @property {boolean} _decoded
+ * @property {ParsedURL} _parsedUrl
+ */
+
+/**
+ * @param {Request} req
+ * @param {boolean} [toDecode]
+ * @returns {ParsedURL|void}
+ */
 export default function (req, toDecode) {
-	let url = req.url;
-	if (url == null) return;
+	let raw = req.url;
+	if (raw == null) return;
 
-	let obj = req._parsedUrl;
-	if (obj && obj._raw === url) return obj;
+	let prev = req._parsedUrl;
+	if (prev && prev.raw === raw) return prev;
 
-	obj = {
-		path: url,
-		pathname: url,
-		search: null,
-		query: null,
-		href: url,
-		_raw: url
-	};
+	let pathname=raw, search='', query;
 
-	if (url.length > 1) {
-		if (toDecode && !req._decoded && !!~url.indexOf('%', 1)) {
-			let nxt = url;
-			try { nxt = decodeURIComponent(url) } catch (e) {/* bad */}
-			url = req.url = obj.href = obj.path = obj.pathname = obj._raw = nxt;
-			req._decoded = true;
-		}
-
-		let idx = url.indexOf('?', 1);
+	if (raw.length > 1) {
+		let idx = raw.indexOf('?', 1);
 
 		if (idx !== -1) {
-			obj.search = url.substring(idx);
-			obj.query = obj.search.substring(1);
-			obj.pathname = url.substring(0, idx);
-			if (toDecode && obj.query.length > 0) {
-				obj.query = parse(obj.query);
+			search = raw.substring(idx);
+			pathname = raw.substring(0, idx);
+			if (search.length > 1) {
+				query = qs.parse(search.substring(1));
+			}
+		}
+
+		if (!!toDecode && !req._decoded) {
+			req._decoded = true;
+			if (pathname.indexOf('%') !== -1) {
+				try { pathname = decodeURIComponent(pathname) }
+				catch (e) { /* URI malformed */ }
 			}
 		}
 	}
 
-	return (req._parsedUrl = obj);
+	return req._parsedUrl = { pathname, search, query, raw };
 }

--- a/packages/url/test/index.js
+++ b/packages/url/test/index.js
@@ -1,6 +1,6 @@
 import { test } from 'uvu';
 import * as assert from 'uvu/assert';
-import parse from '../index';
+import { parse } from '../index';
 
 /**
  * @param {string} url


### PR DESCRIPTION
Took the opportunity to make it a breaking change:

- removed useless keys on `ParsedURL` interface
- use named `parse` export instead of default function

Technically, this means it's a breaking change for Polka too. Specifically, the `req.url` is no longer **fully** decoded. 
Now, `req.url` is the decoded `req.path` segment concatenated with the NOT-decoded `req.search` segment. Before this change, the `req.url` was comprised of a decoded `req.search` segment too... which often caused problems in userland.

The raw, fully-encoded value is always still available as `req.originalUrl` ... unless you change it.

Lastly, revamped the `@polka/url` benchmarks and it looks like it got a bit of a speed boost too 🚀 

---

Closes #150

