### PR TITLE
feat: typescript node16 resolution support

### DIFF
--- a/packages/cluster/package.json
+++ b/packages/cluster/package.json
@@ -9,9 +9,9 @@
   "license": "MIT",
   "exports": {
     ".": {
+      "types": "./index.d.ts",
       "import": "./build.mjs",
-      "require": "./build.js",
-      "types": "./index.d.ts"
+      "require": "./build.js"
     },
     "./package.json": "./package.json"
   },

--- a/packages/cluster/package.json
+++ b/packages/cluster/package.json
@@ -10,7 +10,8 @@
   "exports": {
     ".": {
       "import": "./build.mjs",
-      "require": "./build.js"
+      "require": "./build.js",
+      "types": "./index.d.ts"
     },
     "./package.json": "./package.json"
   },

--- a/packages/parse/package.json
+++ b/packages/parse/package.json
@@ -9,9 +9,9 @@
   "license": "MIT",
   "exports": {
     ".": {
+      "types": "./index.d.ts",
       "import": "./build.mjs",
-      "require": "./build.js",
-      "types": "./index.d.ts"
+      "require": "./build.js"
     },
     "./package.json": "./package.json"
   },

--- a/packages/parse/package.json
+++ b/packages/parse/package.json
@@ -10,7 +10,8 @@
   "exports": {
     ".": {
       "import": "./build.mjs",
-      "require": "./build.js"
+      "require": "./build.js",
+      "types": "./index.d.ts"
     },
     "./package.json": "./package.json"
   },

--- a/packages/polka/package.json
+++ b/packages/polka/package.json
@@ -9,9 +9,9 @@
   "license": "MIT",
   "exports": {
     ".": {
+      "types": "./index.d.ts",
       "import": "./build.mjs",
-      "require": "./build.js",
-      "types": "./index.d.ts"
+      "require": "./build.js"
     },
     "./package.json": "./package.json"
   },

--- a/packages/polka/package.json
+++ b/packages/polka/package.json
@@ -10,7 +10,8 @@
   "exports": {
     ".": {
       "import": "./build.mjs",
-      "require": "./build.js"
+      "require": "./build.js",
+      "types": "./index.d.ts"
     },
     "./package.json": "./package.json"
   },

--- a/packages/redirect/package.json
+++ b/packages/redirect/package.json
@@ -9,9 +9,9 @@
   "license": "MIT",
   "exports": {
     ".": {
+      "types": "./index.d.ts",
       "import": "./build.mjs",
-      "require": "./build.js",
-      "types": "./index.d.ts"
+      "require": "./build.js"
     },
     "./package.json": "./package.json"
   },

--- a/packages/redirect/package.json
+++ b/packages/redirect/package.json
@@ -10,7 +10,8 @@
   "exports": {
     ".": {
       "import": "./build.mjs",
-      "require": "./build.js"
+      "require": "./build.js",
+      "types": "./index.d.ts"
     },
     "./package.json": "./package.json"
   },

--- a/packages/send/package.json
+++ b/packages/send/package.json
@@ -9,9 +9,9 @@
   "license": "MIT",
   "exports": {
     ".": {
+      "types": "./index.d.ts",
       "import": "./build.mjs",
-      "require": "./build.js",
-      "types": "./index.d.ts"
+      "require": "./build.js"
     },
     "./package.json": "./package.json"
   },

--- a/packages/send/package.json
+++ b/packages/send/package.json
@@ -10,7 +10,8 @@
   "exports": {
     ".": {
       "import": "./build.mjs",
-      "require": "./build.js"
+      "require": "./build.js",
+      "types": "./index.d.ts"
     },
     "./package.json": "./package.json"
   },

--- a/packages/url/package.json
+++ b/packages/url/package.json
@@ -9,9 +9,9 @@
   "license": "MIT",
   "exports": {
     ".": {
+      "types": "./index.d.ts",
       "import": "./build.mjs",
-      "require": "./build.js",
-      "types": "./index.d.ts"
+      "require": "./build.js"
     },
     "./package.json": "./package.json"
   },

--- a/packages/url/package.json
+++ b/packages/url/package.json
@@ -10,7 +10,8 @@
   "exports": {
     ".": {
       "import": "./build.mjs",
-      "require": "./build.js"
+      "require": "./build.js",
+      "types": "./index.d.ts"
     },
     "./package.json": "./package.json"
   },


### PR DESCRIPTION
Ref: https://devblogs.microsoft.com/typescript/announcing-typescript-4-7/#package-json-exports-imports-and-self-referencing

This package is currently incompatible with `"moduleResolution": "node16"`, as without an explicit `types` field, TSC looks for `build.d.ts`, therefore reporting that no type declarations are available.