### PR TITLE
chore: format types

### DIFF
--- a/packages/polka/index.d.mts
+++ b/packages/polka/index.d.mts
@@ -61,6 +61,6 @@ export interface Polka<T extends Request = Request> extends Trouter<Middleware<T
 	listen(handle: any, callback?: ListenCallback): this;
 }
 
-export default function<T extends Request = Request>(
+export default function <T extends Request = Request>(
 	options?: IOptions<T>
 ): Polka<T>;


### PR DESCRIPTION
The types were correct, but `function<T` is triggering a weird edge case in rollup-plugin-dts. Adding a space fixes that. However, I agree the fix should be made there, and I'm okay if this is not accepted.