### PR TITLE
perf(compression): use regex exec instead of match

### DIFF
--- a/packages/compression/index.js
+++ b/packages/compression/index.js
@@ -27,7 +27,7 @@ export default function ({ threshold = 1024, level = -1, brotli = false, gzip = 
 
 	return (req, res, next = NOOP) => {
 		const accept = req.headers['accept-encoding'] + '';
-		const encoding = ((brotli && accept.match(/\bbr\b/)) || (gzip && accept.match(/\bgzip\b/)) || [])[0];
+		const encoding = ((brotli && /\bbr\b/.exec(accept)) || (gzip && /\bgzip\b/.exec(accept)) || [])[0];
 
 		// skip if no response body or no supported encoding:
 		if (req.method === 'HEAD' || !encoding) return next();


### PR DESCRIPTION
I was running `eslint-plugin-regexp` in polka and found we can refactor the `str.match(re)` to `re.exec(str)` for perf.

```
/Users/bjorn/Work/oss/vite/node_modules/.pnpm/@polka+compression@1.0.0-next.25/node_modules/@polka/compression/build.js
  30:32  error  Use the `RegExp#exec()` method instead  regexp/prefer-regexp-exec
  30:68  error  Use the `RegExp#exec()` method instead  regexp/prefer-regexp-exec
```

I made some tests and can confirm there's a sizable perf improvement with exec. ([perf.link test](https://perf.link/#eyJpZCI6IndtaW0yb2VtNXU5IiwidGl0bGUiOiJyZWdleCBleGVjIHZzIG1hdGNoIiwiYmVmb3JlIjoiY29uc3QgcmUgPSAvXFxiYnJcXGIvXG5jb25zdCBzdHJzID0gQXJyYXkuZnJvbSh7IGxlbmd0aDogMTAwMCB9KS5tYXAoXyA9PiBNYXRoLnJhbmRvbSgpLnRvU3RyaW5nKDM2KS5zbGljZSgyKSkiLCJ0ZXN0cyI6W3sibmFtZSI6ImV4ZWMiLCJjb2RlIjoic3Rycy5mb3JFYWNoKHMgPT4geyByZS5leGVjKHMpIH0pIiwicnVucyI6WzE3MDAwLDExMDAwLDQ5MDAwLDUwMDAsMTAwMCw4NjAwMCwxMzkwMDAsMTAwMCw3MTAwMCwxMDAwLDE4NDAwMCwxMDAwLDExMjAwMCwxMDMwMDAsMTIyMDAwLDE2NTAwMCwxNjYwMDAsMTUxMDAwLDEwMDAsMTAwMCwxMDAwLDgwMDAsMTI1MDAwLDEyMDAwMCwxMzEwMDAsMTAwMCwzMDAwLDEwMDAsMTQ2MDAwLDUyMDAwLDI5MDAwLDM3MDAwLDE2MTAwMCwxMTYwMDAsMTI2MDAwLDEwMDAsMTAwMCwxNzAwMDAsODAwMCwxNTYwMDAsMTAwMCwxMDAwLDgxMDAwLDEwMDAsMTAwMCwzNjAwMCwxMDAwLDEzMjAwMCwxMDAwLDEwMDAsMjAwMCw0NjAwMCwxMDAwLDEyNTAwMCwxMDAwLDg1MDAwLDg4MDAwLDEwMDAsODIwMDAsMTAwMCw2MDAwLDE1ODAwMCwxMDAwLDE1NTAwMCwzMTAwMCwxMDAwLDgxMDAwLDEwMDAsNDAwMCw3NTAwMCwxMDAwLDQ1MDAwLDEwMDAsNzgwMDAsMTE3MDAwLDEwMDAsOTYwMDAsMTAwMCwzMjAwMCwxMDAwLDEwMDAsMjAwMCw3NjAwMCw1NTAwMCwzNTAwMCwxMjAwMDAsMjEwMDAsNDUwMDAsODYwMDAsOTQwMDAsNDcwMDAsODAwMDAsMjAwMCwzMzAwMCwxMTAwMCw5NjAwMCwxMDAwLDExMzAwMCwxMDAwLDMxMDAwXSwib3BzIjo1MzA0MH0seyJuYW1lIjoibWF0Y2giLCJjb2RlIjoic3Rycy5mb3JFYWNoKHMgPT4geyBzLm1hdGNoKHJlKSB9KSIsInJ1bnMiOlszMDAwLDEwMDAsMTAwMCwxMDAwLDEwMDAsMTMwMDAsMTYwMDAsNDAwMCw5MDAwLDE3MDAwLDEwMDAsMTAwMCwxNTAwMCwxNzAwMCwxOTAwMCwxMDAwLDEwMDAsMTAwMCwxMDAwLDEwMDAsMjAwMDAsMzAwMCwxMDAwMCwxMzAwMCwxNjAwMCwxNjAwMCwxMzAwMCwxNjAwMCwxMzAwMCwxMDAwLDUwMDAsMTEwMDAsMTMwMDAsMTAwMCwxNzAwMCwxMDAwLDEzMDAwLDExMDAwLDMwMDAsMTQwMDAsMTIwMDAsMTAwMCwxMzAwMCwxODAwMCwxMDAwLDcwMDAsMTUwMDAsMTIwMDAsMTUwMDAsMTgwMDAsMTAwMCwxMDAwMCwxODAwMCwxMDAwLDEwMDAsMTEwMDAsMTAwMCwxMDAwLDExMDAwLDEwMDAsMjAwMCwxMDAwLDEwMDAsMTEwMDAsOTAwMCwxMDAwLDEzMDAwLDEwMDAsMzAwMCw5MDAwLDEwMDAsOTAwMCwxMDAwLDE2MDAwLDEzMDAwLDEwMDAsNjAwMCwxMDAwLDEwMDAsMTUwMDAsMTYwMDAsMTYwMDAsMjAwMCwxMDAwLDYwMDAsMTYwMDAsNDAwMCwxMzAwMCwxMTAwMCwxNDAwMCwzMDAwLDEyMDAwLDEwMDAsMjAwMCw0MDAwLDcwMDAsMTAwMCw3MDAwLDE2MDAwLDcwMDBdLCJvcHMiOjc3NjB9XSwidXBkYXRlZCI6IjIwMjQtMDctMjZUMDk6MjM6MDAuNTUxWiJ9))