### PR TITLE
feat(compression): compress wasm files by default

### DIFF
--- a/packages/compression/index.d.mts
+++ b/packages/compression/index.d.mts
@@ -23,7 +23,7 @@ export type Options = {
 	gzip?: boolean;
 	/**
 	 * Regular expression of response MIME types to compress.
-	 * @default /text|javascript|\/json|xml/i
+	 * @default /text|javascript|\/json|xml|wasm/i
 	 */
 	mimes?: RegExp;
 };

--- a/packages/compression/index.d.ts
+++ b/packages/compression/index.d.ts
@@ -24,7 +24,7 @@ declare namespace compression {
 		gzip?: boolean;
 		/**
 		 * Regular expression of response MIME types to compress.
-		 * @default /text|javascript|\/json|xml/i
+		 * @default /text|javascript|\/json|xml|wasm/i
 		 */
 		mimes?: RegExp;
 	};

--- a/packages/compression/index.js
+++ b/packages/compression/index.js
@@ -3,7 +3,7 @@
 import zlib from 'node:zlib';
 
 const NOOP = () => {};
-const MIMES = /text|javascript|\/json|xml/i;
+const MIMES = /text|javascript|\/json|xml|wasm/i;
 
 /**
  * @param {any} chunk

--- a/packages/compression/readme.md
+++ b/packages/compression/readme.md
@@ -67,7 +67,7 @@ Enables response compression using Gzip for requests that support it, as determi
 
 #### options.mimes
 Type: `RegExp`<br>
-Default: `/text|javascript|\/json|xml/i`
+Default: `/text|javascript|\/json|xml|wasm/i`
 
 The `Content-Type` response header is evaluated against this Regular Expression to determine if it is a MIME type that should be compressed.
 


### PR DESCRIPTION
WebAssembly files are compressible (I get a roughly 3:1 compression ratio with gzip) and common in web applications.