### PR TITLE
Use the "http.Server" type instead of "net.Server"

### DIFF
--- a/packages/polka/index.d.ts
+++ b/packages/polka/index.d.ts
@@ -1,5 +1,5 @@
-import type { IncomingMessage, ServerResponse } from 'http';
-import type { ListenOptions, Server } from 'net';
+import type { IncomingMessage, Server, ServerResponse } from 'http';
+import type { ListenOptions } from 'net';
 import type { ParsedURL } from '@polka/url';
 import type { Trouter } from 'trouter';
 


### PR DESCRIPTION
 Hello, thanks for this project! While working on a PR for SvelteKit, I noticed that `polka.server` was typed as a [net.Server](https://nodejs.org/api/net.html#class-netserver) instead of an [http.Server](https://nodejs.org/api/http.html#class-httpserver). Since this project is a web server, I figured that using the latter would be more appropriate. It _should_ be backwards compatible with all existing code because `http.Server` extends `net.Server`. Plus, it'll make the types more accurate for some of the tweaks made by SvelteKit's [adapter-node](https://github.com/sveltejs/kit/tree/main/packages/adapter-node) ([example](https://github.com/sveltejs/kit/blob/0280f4b03bfb48899d9eee212b21499d746c73b9/packages/adapter-node/src/index.js#L53), [example](https://github.com/sveltejs/kit/blob/0280f4b03bfb48899d9eee212b21499d746c73b9/packages/adapter-node/src/index.js#L72)).