### PR TITLE
chore: add polka package support metadata

### DIFF
--- a/packages/polka/package.json
+++ b/packages/polka/package.json
@@ -3,6 +3,10 @@
   "version": "0.5.2",
   "description": "A micro web server so fast, it'll make you dance! :dancers:",
   "repository": "lukeed/polka",
+  "homepage": "https://github.com/lukeed/polka#readme",
+  "bugs": {
+    "url": "https://github.com/lukeed/polka/issues"
+  },
   "license": "MIT",
   "files": [
     "*.js"

--- a/packages/send-type/package.json
+++ b/packages/send-type/package.json
@@ -3,6 +3,10 @@
   "version": "0.5.2",
   "description": "A response helper that detects & handles Content-Types",
   "repository": "lukeed/polka",
+  "homepage": "https://github.com/lukeed/polka#readme",
+  "bugs": {
+    "url": "https://github.com/lukeed/polka/issues"
+  },
   "license": "MIT",
   "files": [
     "*.js"

--- a/packages/send/package.json
+++ b/packages/send/package.json
@@ -3,6 +3,10 @@
   "version": "0.4.0",
   "description": "An extremely simple response helper",
   "repository": "lukeed/polka",
+  "homepage": "https://github.com/lukeed/polka#readme",
+  "bugs": {
+    "url": "https://github.com/lukeed/polka/issues"
+  },
   "license": "MIT",
   "files": [
     "*.js"

--- a/packages/url/package.json
+++ b/packages/url/package.json
@@ -3,6 +3,10 @@
   "version": "0.5.0",
   "description": "Super fast, memoized `req.url` parser",
   "repository": "lukeed/polka",
+  "homepage": "https://github.com/lukeed/polka#readme",
+  "bugs": {
+    "url": "https://github.com/lukeed/polka/issues"
+  },
   "license": "MIT",
   "files": [
     "*.js"


### PR DESCRIPTION
## Summary
- add npm `homepage` metadata for the published Polka packages
- add npm `bugs.url` metadata pointing to the GitHub issue tracker
- cover `polka`, `@polka/send`, `@polka/send-type`, and `@polka/url`
- leave runtime code, dependencies, versions, and package contents unchanged

## Validation
- `node - <<'NODE' ...` metadata assertion for all four package manifests
- `git diff --check`
- `npm pack --dry-run --ignore-scripts --json` for each changed package
